### PR TITLE
Fix frontend error handling

### DIFF
--- a/src/frontend/flask_server.py
+++ b/src/frontend/flask_server.py
@@ -241,7 +241,7 @@ def _submit_transaction(transaction_data):
     try:
         resp.raise_for_status() # Raise on HTTP Status code 4XX or 5XX
     except requests.exceptions.HTTPError as err:
-        raise UserWarning(resp.json().get('msg', ''))
+        raise UserWarning(resp.text)
 
 
 def _add_contact(label, acct_num, routing_num, is_external_acct=False):
@@ -268,7 +268,7 @@ def _add_contact(label, acct_num, routing_num, is_external_acct=False):
     try:
         resp.raise_for_status() # Raise on HTTP Status code 4XX or 5XX
     except requests.exceptions.HTTPError as err:
-        raise UserWarning(resp.json().get('msg', ''))
+        raise UserWarning(resp.text)
 
 
 @APP.route("/login", methods=['GET'])

--- a/src/ledgerwriter/src/main/java/anthos/samples/financedemo/ledgerwriter/LedgerWriterController.java
+++ b/src/ledgerwriter/src/main/java/anthos/samples/financedemo/ledgerwriter/LedgerWriterController.java
@@ -136,12 +136,12 @@ public final class LedgerWriterController {
             return new ResponseEntity<String>("not authorized",
                                               HttpStatus.UNAUTHORIZED);
         } catch (IllegalArgumentException | IllegalStateException e) {
-            return new ResponseEntity<String>(e.toString(),
+            return new ResponseEntity<String>(e.getMessage(),
                                               HttpStatus.BAD_REQUEST);
         } catch (ResourceAccessException
                 | CannotCreateTransactionException
                 | HttpServerErrorException e) {
-            return new ResponseEntity<String>(e.toString(),
+            return new ResponseEntity<String>(e.getMessage(),
                                               HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }


### PR DESCRIPTION
Resolves https://github.com/GoogleCloudPlatform/bank-of-anthos/issues/155

The frontend was expexting errors in json form with a 'msg' field. The ledgerwriter was outputting string error messages. This was causing a frontend crash

This PR fixes that issue, and uses `.getMessage()` for cleaner exception error messages