### PR TITLE
Plain text Python errors

### DIFF
--- a/src/contacts/contacts.py
+++ b/src/contacts/contacts.py
@@ -73,10 +73,10 @@ def create_app():
             contacts_list = contacts_db.get_contacts(username)
             return jsonify(contacts_list), 200
         except (PermissionError, jwt.exceptions.InvalidTokenError):
-            return jsonify({"msg": "authentication denied"}), 401
+            return "authentication denied", 401
         except SQLAlchemyError as err:
             app.logger.error(err)
-            return jsonify({"msg": "failed to retrieve contacts list"}), 500
+            return "failed to retrieve contacts list", 500
 
     @app.route("/contacts/<username>", methods=["POST"])
     def add_contact(username):
@@ -122,14 +122,14 @@ def create_app():
             return jsonify({}), 201
 
         except (PermissionError, jwt.exceptions.InvalidTokenError):
-            return jsonify({"msg": "authentication denied"}), 401
+            return "authentication denied", 401
         except UserWarning as warn:
-            return jsonify({"msg": str(warn)}), 400
+            return str(warn), 400
         except ValueError as err:
-            return jsonify({"msg": str(err)}), 409
+            return str(err), 409
         except SQLAlchemyError as err:
             app.logger.error(err)
-            return jsonify({"msg": "failed to add contact"}), 500
+            return "failed to add contact", 500
 
     def _validate_new_contact(req):
         """Check that this new contact request has valid fields"""

--- a/src/contacts/tests/test_contacts.py
+++ b/src/contacts/tests/test_contacts.py
@@ -131,7 +131,7 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.json["msg"], "may not add yourself to contacts"
+            response.text, "may not add yourself to contacts"
         )
 
     def test_create_contact_409_status_code_duplicate_contact_with_diff_label(self,):
@@ -153,7 +153,7 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.json["msg"], "account already exists as a contact"
+            response.text, "account already exists as a contact"
         )
 
     def test_create_contact_409_status_code_duplicate_contact_with_same_label(self,):
@@ -174,7 +174,7 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.json["msg"], "contact already exists with that label"
+            response.text, "contact already exists with that label"
         )
 
     def test_create_contact_400_status_code_invalid_account_number_less_than_ten_digits(self,):
@@ -191,7 +191,7 @@ class TestContacts(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.json["msg"], "invalid account number")
+            self.assertEqual(response.text, "invalid account number")
 
     def test_create_contact_400_status_code_invalid_routing_number_more_than_nine_digits(self,):
         """test adding a contact with invalid routing number"""
@@ -207,7 +207,7 @@ class TestContacts(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.json["msg"], "invalid routing number")
+            self.assertEqual(response.text, "invalid routing number")
 
     def test_create_contact_400_status_code_is_external_routing_num_equals_local_routing(self,):
         """test adding a contact with same routing number as contact service local routing number"""
@@ -226,7 +226,7 @@ class TestContacts(unittest.TestCase):
         # assert 400 response code
         self.assertEqual(response.status_code, 400)
         # assert we get correct error message
-        self.assertEqual(response.json["msg"], "invalid routing number")
+        self.assertEqual(response.text, "invalid routing number")
 
     def test_create_contact_400_status_code_invalid_labels(self,):
         """test adding a contact with invalid labels """
@@ -242,7 +242,7 @@ class TestContacts(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.json["msg"], "invalid account label")
+            self.assertEqual(response.text, "invalid account label")
 
     def test_create_contact_500_add_contact_failure(self):
         """test adding a contact but throws SQL error when trying to add"""
@@ -259,7 +259,7 @@ class TestContacts(unittest.TestCase):
         # assert 500 response code
         self.assertEqual(response.status_code, 500)
         # assert we get correct error message
-        self.assertEqual(response.json["msg"], "failed to add contact")
+        self.assertEqual(response.text, "failed to add contact")
 
     def test_create_contact_400_add_contact_invalid_auth(self):
         """test adding a contact with invalid auth"""
@@ -277,7 +277,7 @@ class TestContacts(unittest.TestCase):
         # assert 401 response code
         self.assertEqual(response.status_code, 401)
         # assert we get correct error message
-        self.assertEqual(response.json["msg"], "authentication denied")
+        self.assertEqual(response.text, "authentication denied")
 
     def test_get_contacts_200_list_of_contacts(self):
         """test getting a list of contacts for a user"""
@@ -313,7 +313,7 @@ class TestContacts(unittest.TestCase):
         # assert 200 response code
         self.assertEqual(response.status_code, 401)
         # assert we get correct error message
-        self.assertEqual(response.json["msg"], "authentication denied")
+        self.assertEqual(response.text, "authentication denied")
 
     def test_get_contacts_500_get_contacts_failure(self):
         """test getting contacts but throws SQL error"""
@@ -327,5 +327,5 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 500)
         # assert we get correct error message
         self.assertEqual(
-            response.json["msg"], "failed to retrieve contacts list"
+            response.text, "failed to retrieve contacts list"
         )

--- a/src/contacts/tests/test_contacts.py
+++ b/src/contacts/tests/test_contacts.py
@@ -131,7 +131,7 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.data, "may not add yourself to contacts"
+            response.data, b"may not add yourself to contacts"
         )
 
     def test_create_contact_409_status_code_duplicate_contact_with_diff_label(self,):
@@ -153,7 +153,7 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.data, "account already exists as a contact"
+            response.data, b"account already exists as a contact"
         )
 
     def test_create_contact_409_status_code_duplicate_contact_with_same_label(self,):
@@ -174,7 +174,7 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.data, "contact already exists with that label"
+            response.data, b"contact already exists with that label"
         )
 
     def test_create_contact_400_status_code_invalid_account_number_less_than_ten_digits(self,):
@@ -191,7 +191,7 @@ class TestContacts(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.data, "invalid account number")
+            self.assertEqual(response.data, b"invalid account number")
 
     def test_create_contact_400_status_code_invalid_routing_number_more_than_nine_digits(self,):
         """test adding a contact with invalid routing number"""
@@ -207,7 +207,7 @@ class TestContacts(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.data, "invalid routing number")
+            self.assertEqual(response.data, b"invalid routing number")
 
     def test_create_contact_400_status_code_is_external_routing_num_equals_local_routing(self,):
         """test adding a contact with same routing number as contact service local routing number"""
@@ -226,7 +226,7 @@ class TestContacts(unittest.TestCase):
         # assert 400 response code
         self.assertEqual(response.status_code, 400)
         # assert we get correct error message
-        self.assertEqual(response.data, "invalid routing number")
+        self.assertEqual(response.data, b"invalid routing number")
 
     def test_create_contact_400_status_code_invalid_labels(self,):
         """test adding a contact with invalid labels """
@@ -242,7 +242,7 @@ class TestContacts(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.data, "invalid account label")
+            self.assertEqual(response.data, b"invalid account label")
 
     def test_create_contact_500_add_contact_failure(self):
         """test adding a contact but throws SQL error when trying to add"""
@@ -259,7 +259,7 @@ class TestContacts(unittest.TestCase):
         # assert 500 response code
         self.assertEqual(response.status_code, 500)
         # assert we get correct error message
-        self.assertEqual(response.data, "failed to add contact")
+        self.assertEqual(response.data, b"failed to add contact")
 
     def test_create_contact_400_add_contact_invalid_auth(self):
         """test adding a contact with invalid auth"""
@@ -277,7 +277,7 @@ class TestContacts(unittest.TestCase):
         # assert 401 response code
         self.assertEqual(response.status_code, 401)
         # assert we get correct error message
-        self.assertEqual(response.data, "authentication denied")
+        self.assertEqual(response.data, b"authentication denied")
 
     def test_get_contacts_200_list_of_contacts(self):
         """test getting a list of contacts for a user"""
@@ -313,7 +313,7 @@ class TestContacts(unittest.TestCase):
         # assert 200 response code
         self.assertEqual(response.status_code, 401)
         # assert we get correct error message
-        self.assertEqual(response.data, "authentication denied")
+        self.assertEqual(response.data, b"authentication denied")
 
     def test_get_contacts_500_get_contacts_failure(self):
         """test getting contacts but throws SQL error"""
@@ -327,5 +327,5 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 500)
         # assert we get correct error message
         self.assertEqual(
-            response.data, "failed to retrieve contacts list"
+            response.data, b"failed to retrieve contacts list"
         )

--- a/src/contacts/tests/test_contacts.py
+++ b/src/contacts/tests/test_contacts.py
@@ -131,7 +131,7 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.text, "may not add yourself to contacts"
+            response.data, "may not add yourself to contacts"
         )
 
     def test_create_contact_409_status_code_duplicate_contact_with_diff_label(self,):
@@ -153,7 +153,7 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.text, "account already exists as a contact"
+            response.data, "account already exists as a contact"
         )
 
     def test_create_contact_409_status_code_duplicate_contact_with_same_label(self,):
@@ -174,7 +174,7 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.text, "contact already exists with that label"
+            response.data, "contact already exists with that label"
         )
 
     def test_create_contact_400_status_code_invalid_account_number_less_than_ten_digits(self,):
@@ -191,7 +191,7 @@ class TestContacts(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.text, "invalid account number")
+            self.assertEqual(response.data, "invalid account number")
 
     def test_create_contact_400_status_code_invalid_routing_number_more_than_nine_digits(self,):
         """test adding a contact with invalid routing number"""
@@ -207,7 +207,7 @@ class TestContacts(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.text, "invalid routing number")
+            self.assertEqual(response.data, "invalid routing number")
 
     def test_create_contact_400_status_code_is_external_routing_num_equals_local_routing(self,):
         """test adding a contact with same routing number as contact service local routing number"""
@@ -226,7 +226,7 @@ class TestContacts(unittest.TestCase):
         # assert 400 response code
         self.assertEqual(response.status_code, 400)
         # assert we get correct error message
-        self.assertEqual(response.text, "invalid routing number")
+        self.assertEqual(response.data, "invalid routing number")
 
     def test_create_contact_400_status_code_invalid_labels(self,):
         """test adding a contact with invalid labels """
@@ -242,7 +242,7 @@ class TestContacts(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.text, "invalid account label")
+            self.assertEqual(response.data, "invalid account label")
 
     def test_create_contact_500_add_contact_failure(self):
         """test adding a contact but throws SQL error when trying to add"""
@@ -259,7 +259,7 @@ class TestContacts(unittest.TestCase):
         # assert 500 response code
         self.assertEqual(response.status_code, 500)
         # assert we get correct error message
-        self.assertEqual(response.text, "failed to add contact")
+        self.assertEqual(response.data, "failed to add contact")
 
     def test_create_contact_400_add_contact_invalid_auth(self):
         """test adding a contact with invalid auth"""
@@ -277,7 +277,7 @@ class TestContacts(unittest.TestCase):
         # assert 401 response code
         self.assertEqual(response.status_code, 401)
         # assert we get correct error message
-        self.assertEqual(response.text, "authentication denied")
+        self.assertEqual(response.data, "authentication denied")
 
     def test_get_contacts_200_list_of_contacts(self):
         """test getting a list of contacts for a user"""
@@ -313,7 +313,7 @@ class TestContacts(unittest.TestCase):
         # assert 200 response code
         self.assertEqual(response.status_code, 401)
         # assert we get correct error message
-        self.assertEqual(response.text, "authentication denied")
+        self.assertEqual(response.data, "authentication denied")
 
     def test_get_contacts_500_get_contacts_failure(self):
         """test getting contacts but throws SQL error"""
@@ -327,5 +327,5 @@ class TestContacts(unittest.TestCase):
         self.assertEqual(response.status_code, 500)
         # assert we get correct error message
         self.assertEqual(
-            response.text, "failed to retrieve contacts list"
+            response.data, "failed to retrieve contacts list"
         )

--- a/src/userservice/tests/test_userservice.py
+++ b/src/userservice/tests/test_userservice.py
@@ -125,7 +125,8 @@ class TestUserservice(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            str(response.data), 'user {} already exists'.format(example_user_request['username'])
+            response.data,
+            'user {} already exists'.format(example_user_request['username']).encode()
         )
 
     def test_create_user_sql_error_500_status_code_error_message(self):
@@ -238,5 +239,6 @@ class TestUserservice(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         # assert we get correct error message
         self.assertEqual(
-            str(response.data), 'user {} does not exist'.format(example_user_request['username'])
+            response.data,
+            'user {} does not exist'.format(example_user_request['username']).encode()
         )

--- a/src/userservice/tests/test_userservice.py
+++ b/src/userservice/tests/test_userservice.py
@@ -125,7 +125,7 @@ class TestUserservice(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.text, 'user {} already exists'.format(example_user_request['username'])
+            response.data, b'user {} already exists'.format(example_user_request['username'])
         )
 
     def test_create_user_sql_error_500_status_code_error_message(self):
@@ -142,7 +142,7 @@ class TestUserservice(unittest.TestCase):
         # assert 500 response code
         self.assertEqual(response.status_code, 500)
         # assert we get correct error message
-        self.assertEqual(response.text, 'failed to create user')
+        self.assertEqual(response.data, b'failed to create user')
 
     def test_create_user_malformed_400_status_code_error_message(self):
         """test creating a new user without required keys"""
@@ -157,7 +157,7 @@ class TestUserservice(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.text, 'missing required field(s)')
+            self.assertEqual(response.data, b'missing required field(s)')
 
     def test_create_user_malformed_empty_400_status_code_error_message(self):
         """test creating a new user with empty value for required key"""
@@ -170,7 +170,7 @@ class TestUserservice(unittest.TestCase):
         # assert 400 response code
         self.assertEqual(response.status_code, 400)
         # assert we get correct error message
-        self.assertEqual(response.text, 'missing value for input field(s)')
+        self.assertEqual(response.data, b'missing value for input field(s)')
 
     def test_create_user_mismatch_password_400_status_code_error_message(self):
         """test creating a new user with mismatched password values"""
@@ -184,7 +184,7 @@ class TestUserservice(unittest.TestCase):
         # assert 400 response code
         self.assertEqual(response.status_code, 400)
         # assert we get correct error message
-        self.assertEqual(response.text, 'passwords do not match')
+        self.assertEqual(response.data, b'passwords do not match')
 
     # mock check pw to return true to simulate correct password
     @patch('bcrypt.checkpw', return_value=True)
@@ -223,7 +223,7 @@ class TestUserservice(unittest.TestCase):
         # assert 401 response
         self.assertEqual(response.status_code, 401)
         # assert we get correct error message
-        self.assertEqual(response.text, 'invalid login')
+        self.assertEqual(response.data, b'invalid login')
 
     def test_login_non_existent_user_404_status_code_error_message(self):
         """test logging in with a user that does not exist"""
@@ -238,5 +238,5 @@ class TestUserservice(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         # assert we get correct error message
         self.assertEqual(
-            response.text, 'user {} does not exist'.format(example_user_request['username'])
+            response.data, b'user {} does not exist'.format(example_user_request['username'])
         )

--- a/src/userservice/tests/test_userservice.py
+++ b/src/userservice/tests/test_userservice.py
@@ -125,7 +125,7 @@ class TestUserservice(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.data, b'user {} already exists'.format(example_user_request['username'])
+            str(response.data), 'user {} already exists'.format(example_user_request['username'])
         )
 
     def test_create_user_sql_error_500_status_code_error_message(self):
@@ -238,5 +238,5 @@ class TestUserservice(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         # assert we get correct error message
         self.assertEqual(
-            response.data, b'user {} does not exist'.format(example_user_request['username'])
+            str(response.data), 'user {} does not exist'.format(example_user_request['username'])
         )

--- a/src/userservice/tests/test_userservice.py
+++ b/src/userservice/tests/test_userservice.py
@@ -125,7 +125,7 @@ class TestUserservice(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         # assert we get correct error message
         self.assertEqual(
-            response.json['msg'], 'user {} already exists'.format(example_user_request['username'])
+            response.text, 'user {} already exists'.format(example_user_request['username'])
         )
 
     def test_create_user_sql_error_500_status_code_error_message(self):
@@ -142,7 +142,7 @@ class TestUserservice(unittest.TestCase):
         # assert 500 response code
         self.assertEqual(response.status_code, 500)
         # assert we get correct error message
-        self.assertEqual(response.json['msg'], 'failed to create user')
+        self.assertEqual(response.text, 'failed to create user')
 
     def test_create_user_malformed_400_status_code_error_message(self):
         """test creating a new user without required keys"""
@@ -157,7 +157,7 @@ class TestUserservice(unittest.TestCase):
             # assert 400 response code
             self.assertEqual(response.status_code, 400)
             # assert we get correct error message
-            self.assertEqual(response.json['msg'], 'missing required field(s)')
+            self.assertEqual(response.text, 'missing required field(s)')
 
     def test_create_user_malformed_empty_400_status_code_error_message(self):
         """test creating a new user with empty value for required key"""
@@ -170,7 +170,7 @@ class TestUserservice(unittest.TestCase):
         # assert 400 response code
         self.assertEqual(response.status_code, 400)
         # assert we get correct error message
-        self.assertEqual(response.json['msg'], 'missing value for input field(s)')
+        self.assertEqual(response.text, 'missing value for input field(s)')
 
     def test_create_user_mismatch_password_400_status_code_error_message(self):
         """test creating a new user with mismatched password values"""
@@ -184,7 +184,7 @@ class TestUserservice(unittest.TestCase):
         # assert 400 response code
         self.assertEqual(response.status_code, 400)
         # assert we get correct error message
-        self.assertEqual(response.json['msg'], 'passwords do not match')
+        self.assertEqual(response.text, 'passwords do not match')
 
     # mock check pw to return true to simulate correct password
     @patch('bcrypt.checkpw', return_value=True)
@@ -223,7 +223,7 @@ class TestUserservice(unittest.TestCase):
         # assert 401 response
         self.assertEqual(response.status_code, 401)
         # assert we get correct error message
-        self.assertEqual(response.json['msg'], 'invalid login')
+        self.assertEqual(response.text, 'invalid login')
 
     def test_login_non_existent_user_404_status_code_error_message(self):
         """test logging in with a user that does not exist"""
@@ -238,5 +238,5 @@ class TestUserservice(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         # assert we get correct error message
         self.assertEqual(
-            response.json['msg'], 'user {} does not exist'.format(example_user_request['username'])
+            response.text, 'user {} does not exist'.format(example_user_request['username'])
         )

--- a/src/userservice/userservice.py
+++ b/src/userservice/userservice.py
@@ -106,12 +106,12 @@ def create_app():
             users_db.add_user(user_data)
 
         except UserWarning as warn:
-            return jsonify({'msg': str(warn)}), 400
+            return str(warn), 400
         except NameError as err:
-            return jsonify({'msg': str(err)}), 409
+            return str(err), 409
         except SQLAlchemyError as err:
             app.logger.error(err)
-            return jsonify({'msg': 'failed to create user'}), 500
+            return 'failed to create user', 500
 
         return jsonify({}), 201
 
@@ -178,12 +178,12 @@ def create_app():
             return jsonify({'token': token.decode("utf-8")}), 200
 
         except LookupError as err:
-            return jsonify({'msg': str(err)}), 404
+            return str(err), 404
         except PermissionError as err:
-            return jsonify({'msg': str(err)}), 401
+            return str(err), 401
         except SQLAlchemyError as err:
             app.logger.error(err)
-            return jsonify({'msg': 'failed to retrieve user information'}), 500
+            return 'failed to retrieve user information', 500
 
     @atexit.register
     def _shutdown():


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/bank-of-anthos/issues/196

We recently refactored Java to return plaintext error messages, instead of wrapping them in a JSON dictionary. Python was still wrapping in JSON, resulting in unfriendly error messages that could be propagated to the user: 

![image](https://user-images.githubusercontent.com/3914119/83052561-5b484e00-a004-11ea-8251-0f898ed977c7.png)

This PR makes Python services also return plain text on errors