### PR TITLE
Implement ASM / Istio Integration & associated examples and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ kubectl create secret generic jwt-key --from-file=./jwtRS256.key --from-file=./j
 
 ### 5 - Deploy Kubernetes manifests
 
+**Note:** There are also Kubernetes Manifests for an Anthos Service Mesh / Istio deployment. Follow the steps documented [here](./kubernetes-manifests-asm/README.md) to deploy with Anthos Service Mesh / Istio support.
+
 ```
 kubectl apply -f ./kubernetes-manifests
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ kubectl create secret generic jwt-key --from-file=./jwtRS256.key --from-file=./j
 
 ### 5 - Deploy Kubernetes manifests
 
-**Note:** There are also Kubernetes Manifests for an Anthos Service Mesh / Istio deployment. Follow the steps documented [here](./kubernetes-manifests-asm/README.md) to deploy with Anthos Service Mesh / Istio support.
+**Note:** There are also Kubernetes Manifests for an Anthos Service Mesh / Istio deployment. Follow the steps documented [here](./kubernetes-manifests-asm) to deploy with Anthos Service Mesh / Istio support.
 
 ```
 kubectl apply -f ./kubernetes-manifests

--- a/kubernetes-manifests-asm/README.md
+++ b/kubernetes-manifests-asm/README.md
@@ -16,7 +16,7 @@ kubectl label namespace <NAMESPACE> istio-injection=enabled --overwrite
 ## Installation
 
 ### 1-4 - Follow steps in main README
-Follow steps 1 to 4 in [README.md](./README.MD) to setup your Kubernetes Cluster and configure your RSA Keypair
+Follow steps 1 to 4 in [README.md](../) to setup your Kubernetes Cluster and configure your RSA Keypair
 
 ### 5 - Deploy Kubernetes manifests
 
@@ -59,4 +59,4 @@ EXTERNAL-IP
 ```
 
 ### 7 - Follow steps in main README
-Follow step 7 in [README.md](./README.MD) to access the Bank of Anthos web frontend
+Follow step 7 in [README.md](../) to access the Bank of Anthos web frontend

--- a/kubernetes-manifests-asm/README.md
+++ b/kubernetes-manifests-asm/README.md
@@ -1,0 +1,62 @@
+# Kubernetes ASM Manifests
+
+This folder contains an alternate set of Kubernetes Manifests that deploy the Bank of Anthos with ASM support. They should also work with Istio.
+
+Namely - the differences between the Kubernetes Manifests in this directory and those in the [standard Kubernetes Manifests directory](../kubernetes-manifests) is:
+* The exposure of the frontend is performed through an Istio Gateway and Virtual Service instead of via a Load Balancer. This is defined in [asm-gateway.yml](asm-gateway.yml).
+* Each Pod created by the Deployment for each service is labelled with a `version` label.
+* Each service has an accompanying `VirtualService` and `DestinationRule` used for routing traffic.
+
+Before deploying these manifests - you should ensure you have Anthos Service Mesh or Istio installed on your cluster. Additionally you should ensure the namespace you are deploying these manifests to is labelled for automatic sidecar injection:
+
+```
+kubectl label namespace <NAMESPACE> istio-injection=enabled --overwrite
+```
+
+## Installation
+
+### 1-4 - Follow steps in main README
+Follow steps 1 to 4 in [README.md](./README.MD) to setup your Kubernetes Cluster and configure your RSA Keypair
+
+### 5 - Deploy Kubernetes manifests
+
+```
+kubectl apply -f ./kubernetes-manifests-asm
+```
+
+After 1-2 minutes, you should see that all the pods are running:
+
+```
+kubectl get pods
+```
+
+*Example output - do not copy*
+
+```
+NAME                                  READY   STATUS    RESTARTS   AGE
+accounts-db-6f589464bc-6r7b7          2/2     Running   0          99s
+balancereader-797bf6d7c5-8xvp6        2/2     Running   0          99s
+contacts-769c4fb556-25pg2             2/2     Running   0          98s
+frontend-7c96b54f6b-zkdbz             2/2     Running   0          98s
+ledger-db-5b78474d4f-p6xcb            2/2     Running   0          98s
+ledgerwriter-84bf44b95d-65mqf         2/2     Running   0          97s
+loadgenerator-559667b6ff-4zsvb        2/2     Running   0          97s
+transactionhistory-5569754896-z94cn   2/2     Running   0          97s
+userservice-78dc876bff-pdhtl          2/2     Running   0          96s
+```
+
+### 6 - Get the frontend IP
+
+```
+kubectl get svc istio-ingressgateway -n istio-system | awk '{print $4}'
+```
+
+*Example output - do not copy*
+
+```
+EXTERNAL-IP
+35.223.69.29
+```
+
+### 7 - Follow steps in main README
+Follow step 7 in [README.md](./README.MD) to access the Bank of Anthos web frontend

--- a/kubernetes-manifests-asm/accounts-db.yaml
+++ b/kubernetes-manifests-asm/accounts-db.yaml
@@ -31,6 +31,7 @@ spec:
       labels:
         app: accounts-db
         tier: db
+        version: v0.2.0
     spec:
       containers:
       - name: accounts-db
@@ -96,7 +97,7 @@ metadata:
 spec:
   hosts:
   - accounts-db
-  http:
+  tcp:
   - route:
     - destination:
         host: accounts-db

--- a/kubernetes-manifests-asm/accounts-db.yaml
+++ b/kubernetes-manifests-asm/accounts-db.yaml
@@ -1,0 +1,117 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: accounts-db
+  labels:
+    app: accounts-db
+    tier: db
+spec:
+  serviceName: "accounts-db"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: accounts-db
+      tier: db
+  template:
+    metadata:
+      labels:
+        app: accounts-db
+        tier: db
+    spec:
+      containers:
+      - name: accounts-db
+        image: gcr.io/bank-of-anthos/accounts-db:latest
+        envFrom:
+          - configMapRef:
+              name: environment-config
+          - configMapRef:
+              name: accounts-db-config
+          - configMapRef:
+              name: default-data-config
+        ports:
+          - containerPort: 5432
+            name: postgredb
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        volumeMounts:
+        - name: postgresdb
+          mountPath: /var/lib/postgresql/data
+          subPath: postgres
+      volumes:
+      - name: postgresdb
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: accounts-db
+  labels:
+    app: accounts-db
+    tier: db
+spec:
+  ports:
+    - port: 5432
+      name: postgredb
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    app: accounts-db
+    tier: db
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: accounts-db-config
+  labels:
+    app: accounts-db
+data:
+  POSTGRES_DB: accounts-db
+  POSTGRES_USER: accounts-admin
+  POSTGRES_PASSWORD: accounts-pwd
+  ACCOUNTS_DB_URI: postgresql://accounts-admin:accounts-pwd@accounts-db:5432/accounts-db
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: accounts-db
+spec:
+  hosts:
+  - accounts-db
+  http:
+  - route:
+    - destination:
+        host: accounts-db
+        subset: v0-2-0
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: accounts-db-destination
+spec:
+  host: accounts-db
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0

--- a/kubernetes-manifests-asm/asm-examples/README.md
+++ b/kubernetes-manifests-asm/asm-examples/README.md
@@ -33,11 +33,70 @@ fault:
         value: 50
 ```
 
-Here - instead of implementing a delay, we're using the Fault Injection capability to return a HTTP 500 Internal Server Error HTTP response to 50% of the requests.
+Here - instead of implementing a delay, we're using the Fault Injection capability to return a `HTTP 500 Internal Server Error` HTTP response to 50% of the requests.
 
-If you browse to the Bank of Anthos UI at `http://<YOUR INGRESS IP>/` and refresh the page a couple of times. You should notice that approximately 50% of the requests return a `500 Internal Server Error`.
+If you browse to the Bank of Anthos UI at `http://<YOUR INGRESS IP>/` and refresh the page a couple of times. You should notice that approximately 50% of the requests return a `500 Internal Server Error` response.
 
 Clean up the changes by re-applying the original manifest:
 ```
+kubectl apply -f ../asm-gateway.yml
+```
+
+### 2 - Traffic Shifting
+Next - we will experiment with the [Traffic Shifting capability](https://istio.io/latest/docs/tasks/traffic-management/traffic-shifting/) of Anthos Service Mesh by deploying a new version of our [frontend](../../src/frontend) service and managing traffic between the new version and the original.
+
+The frontend service is configured to look for an environment variable named `BANK_NAME`. This environment variable is then shown in the navigation bar of the frontend service. Instead of building a new version of the container, for simplicity we'll instead create a new deployment with a different `BANK_NAME` variable set. This will easily enable us to determine which version of the frontend we are hitting.
+
+Inspect the contents of the [frontend-custom-deployment.yml](frontend-custom-deployment.yml) file. You'll notice that the deployment is similar to the original deployment, but with some minor changes:
+1. We've changed the `name:` of the deployment to `frontend-custom`
+2. We've changed the `version:` label and `VERSION` environment variable to `v0.2.0-custom`
+3. We've added a new environment variable named `BANK_NAME` and set the value to `Bank of Custom`
+
+When applied - this manifest will create a new deployment named `frontend-custom` with the same container image as the `frontend` service - but with the changes detailed above. It will also update the `frontend-destination` Destination Rule with a new subset that will enable us to send traffic to a specific version.
+
+Apply the manifest:
+
+```
+kubectl apply -f frontend-custom-deployment.yml
+```
+
+Check that the new deployment was successfully created:
+```
+kubectl get deployments
+```
+
+*Example output - do not copy*
+
+```
+NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
+frontend-custom      1/1     1            1           67m
+```
+
+At this point - we've successfully deployed the new version of the frontend application - but we're not sending any traffic to it. Inspect the contents of the [frontend-custom-50-50.yml](frontend-custom-50-50.yml) file. You'll notice that we now have two destinations configured under the route:
+
+```
+- destination:
+    host: frontend
+    subset: v0-2-0
+    weight: 50
+- destination:
+    host: frontend
+    subset: v0-2-0-custom
+    weight: 50
+```
+
+Here, we're configuring Anthos Service Mesh to evenly distribute the traffic between the original version of the application, and our new `v0.2.0-custom` version. Apply the manifest:
+
+```
+kubectl apply -f frontend-custom-50-50.yml
+```
+
+If you browse to the Bank of Anthos UI at `http://<YOUR INGRESS IP>/` and refresh the page a couple of times. You should notice that the bank name in the navigation bar changes between `Bank of Anthos` and `Bank of Custom`. This happens as Anthos Service Mesh directs us between different versions of our application.
+
+You can experiment by editing the [frontend-custom-50-50.yml](frontend-custom-50-50.yml) file and changing the traffic distributions. You can also switch over traffic completely to our `v2.0.0-custom` version by applying the [frontend-custom-100-0.yml](frontend-custom-100-0.yml) manifest.
+
+Clean up the changes by deleting the deployment and re-applying the original manifest:
+```
+kubectl delete deployment frontend-custom
 kubectl apply -f ../asm-gateway.yml
 ```

--- a/kubernetes-manifests-asm/asm-examples/README.md
+++ b/kubernetes-manifests-asm/asm-examples/README.md
@@ -1,0 +1,8 @@
+# Bank of Anthos - Anthos Service Mesh Examples
+
+This directory contains a range of manifests that enable you to explore the functionality of Anthos Service Mesh with the Bank of Anthos.
+
+Before performing any of the steps documented below - you should perform the standard deployment using the [provided ASM Manifests](./kubernetes-manifests-asm/README.md).
+
+### 1 - Fault Injection
+First - we will experiment with the [Fault Injection capability](https://istio.io/latest/docs/tasks/traffic-management/fault-injection/) of Anthos Service Mesh and inject some faults into the [frontend](/) service. 

--- a/kubernetes-manifests-asm/asm-examples/README.md
+++ b/kubernetes-manifests-asm/asm-examples/README.md
@@ -5,4 +5,39 @@ This directory contains a range of manifests that enable you to explore the func
 Before performing any of the steps documented below - you should perform the standard deployment using the [provided ASM Manifests](../).
 
 ### 1 - Fault Injection
-First - we will experiment with the [Fault Injection capability](https://istio.io/latest/docs/tasks/traffic-management/fault-injection/) of Anthos Service Mesh and inject some faults into the [frontend](../../src/frontend) service. 
+First - we will experiment with the [Fault Injection capability](https://istio.io/latest/docs/tasks/traffic-management/fault-injection/) of Anthos Service Mesh and inject some faults into the [frontend](../../src/frontend) service.
+
+Inspect the contents of the [frontend-delay-fault-injection.yml](frontend-delay-fault-injection.yml) file. You'll notice the following block under the `route:` section:
+```
+fault:
+    delay:
+    fixedDelay: 10s
+    percentage:
+        value: 50
+```
+
+Here we're using the Fault Injection capability to implement a 10 second delay to 50% of the requests that make it to the [frontend](../../src/frontend) service. Apply the manifest with:
+
+```
+kubectl apply -f frontend-delay-fault-injection.yml
+```
+
+If you browse to the Bank of Anthos UI at `http://<YOUR INGRESS IP>/` and refresh the page a couple of times. You should notice that approximately 50% of the requests are delayed by 10 seconds.
+
+We're not limited to implementing delays - we can also inject other faults such as HTTP Status Codes. Inspect the contents of the [frontend-http500-fault-injection.yml](frontend-http500-fault-injection.yml) file. You'll notice the following block under the `route:` section:
+```
+fault:
+    abort:
+    httpStatus: 500
+    percentage:
+        value: 50
+```
+
+Here - instead of implementing a delay, we're using the Fault Injection capability to return a HTTP 500 Internal Server Error HTTP response to 50% of the requests.
+
+If you browse to the Bank of Anthos UI at `http://<YOUR INGRESS IP>/` and refresh the page a couple of times. You should notice that approximately 50% of the requests return a `500 Internal Server Error`.
+
+Clean up the changes by re-applying the original manifest:
+```
+kubectl apply -f ../asm-gateway.yml
+```

--- a/kubernetes-manifests-asm/asm-examples/README.md
+++ b/kubernetes-manifests-asm/asm-examples/README.md
@@ -4,6 +4,8 @@ This directory contains a range of manifests that enable you to explore the func
 
 Before performing any of the steps documented below - you should perform the standard deployment using the [provided ASM Manifests](../).
 
+The below commands should be executed from this directory.
+
 ### 1 - Fault Injection
 First - we will experiment with the [Fault Injection capability](https://istio.io/latest/docs/tasks/traffic-management/fault-injection/) of Anthos Service Mesh and inject some faults into the [frontend](../../src/frontend) service.
 

--- a/kubernetes-manifests-asm/asm-examples/README.md
+++ b/kubernetes-manifests-asm/asm-examples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a range of manifests that enable you to explore the functionality of Anthos Service Mesh with the Bank of Anthos.
 
-Before performing any of the steps documented below - you should perform the standard deployment using the [provided ASM Manifests](./kubernetes-manifests-asm/README.md).
+Before performing any of the steps documented below - you should perform the standard deployment using the [provided ASM Manifests](../).
 
 ### 1 - Fault Injection
-First - we will experiment with the [Fault Injection capability](https://istio.io/latest/docs/tasks/traffic-management/fault-injection/) of Anthos Service Mesh and inject some faults into the [frontend](/) service. 
+First - we will experiment with the [Fault Injection capability](https://istio.io/latest/docs/tasks/traffic-management/fault-injection/) of Anthos Service Mesh and inject some faults into the [frontend](../../src/frontend) service. 

--- a/kubernetes-manifests-asm/asm-examples/frontend-custom-100-0.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-custom-100-0.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:

--- a/kubernetes-manifests-asm/asm-examples/frontend-custom-100-0.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-custom-100-0.yml
@@ -1,0 +1,22 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: bank-gateway
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+      weight: 0
+    - destination:
+        host: frontend
+        subset: v0-2-0-custom
+      weight: 100

--- a/kubernetes-manifests-asm/asm-examples/frontend-custom-50-50.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-custom-50-50.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:

--- a/kubernetes-manifests-asm/asm-examples/frontend-custom-50-50.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-custom-50-50.yml
@@ -1,0 +1,22 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: bank-gateway
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+      weight: 50
+    - destination:
+        host: frontend
+        subset: v0-2-0-custom
+      weight: 50

--- a/kubernetes-manifests-asm/asm-examples/frontend-custom-deployment.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-custom-deployment.yml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-custom
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+        version: v0.2.0-custom
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: front
+        image: gcr.io/bank-of-anthos/frontend:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0-custom"
+        - name: PORT
+          value: "8080"
+        - name: BANK_NAME
+          value: "Bank of Custom"
+        - name: DEFAULT_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: default-data-config
+              key: DEFAULT_USER_USERNAME
+        - name: DEFAULT_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: default-data-config
+              key: DEFAULT_LOGIN_PASSWORD
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: service-api-config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: frontend-destination
+spec:
+  host: frontend
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0
+  - name: v0-2-0-custom
+    labels:
+      version: v0.2.0-custom

--- a/kubernetes-manifests-asm/asm-examples/frontend-custom-deployment.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-custom-deployment.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes-manifests-asm/asm-examples/frontend-delay-fault-injection.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-delay-fault-injection.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:

--- a/kubernetes-manifests-asm/asm-examples/frontend-delay-fault-injection.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-delay-fault-injection.yml
@@ -1,0 +1,25 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: bank-gateway
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+        port:
+          number: 80
+      weight: 100
+    fault:
+      delay:
+        fixedDelay: 10s
+        percentage:
+          value: 50

--- a/kubernetes-manifests-asm/asm-examples/frontend-http500-fault-injection.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-http500-fault-injection.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:

--- a/kubernetes-manifests-asm/asm-examples/frontend-http500-fault-injection.yml
+++ b/kubernetes-manifests-asm/asm-examples/frontend-http500-fault-injection.yml
@@ -1,0 +1,25 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: bank-gateway
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+        port:
+          number: 80
+      weight: 100
+    fault:
+      abort:
+        httpStatus: 500
+        percentage:
+          value: 50

--- a/kubernetes-manifests-asm/asm-gateway.yml
+++ b/kubernetes-manifests-asm/asm-gateway.yml
@@ -1,0 +1,49 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: bank-of-anthos-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*" 
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: bank-gateway
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bank-of-anthos-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: frontend
+        subset: v0-2-0
+        port:
+          number: 80
+      weight: 100
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: frontend-destination
+spec:
+  host: frontend
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0

--- a/kubernetes-manifests-asm/asm-gateway.yml
+++ b/kubernetes-manifests-asm/asm-gateway.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:

--- a/kubernetes-manifests-asm/balance-reader.yaml
+++ b/kubernetes-manifests-asm/balance-reader.yaml
@@ -1,0 +1,120 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: balancereader
+spec:
+  selector:
+    matchLabels:
+      app: balancereader
+  template:
+    metadata:
+      labels:
+        app: balancereader
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: reader
+        image: gcr.io/bank-of-anthos/balancereader:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        - name: POLL_MS
+          value: "100"
+        - name: CACHE_SIZE
+          value: "1000000"
+        # tell Java to obey container memory limits
+        - name: JVM_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        # add ledger-db credentials from ConfigMap
+        - configMapRef:
+            name: ledger-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: balancereader
+spec:
+  type: ClusterIP
+  selector:
+    app: balancereader
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: balancereader
+spec:
+  hosts:
+  - balancereader
+  http:
+  - route:
+    - destination:
+        host: balancereader
+        subset: v0-2-0
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: balancereader-destination
+spec:
+  host: balancereader
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0

--- a/kubernetes-manifests-asm/config.yaml
+++ b/kubernetes-manifests-asm/config.yaml
@@ -1,0 +1,51 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: environment-config
+data:
+  LOCAL_ROUTING_NUM: "123456789"
+  PUB_KEY_PATH: "/root/.ssh/publickey"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-api-config
+data:
+  TRANSACTIONS_API_ADDR: "ledgerwriter:8080"
+  BALANCES_API_ADDR: "balancereader:8080"
+  HISTORY_API_ADDR: "transactionhistory:8080"
+  CONTACTS_API_ADDR: "contacts:8080"
+  USERSERVICE_API_ADDR: "userservice:8080"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-data-config
+data:
+  USE_DEFAULT_DATA: "True"
+  # All default user accounts are hardcoded to use the login password 'password'
+  DEFAULT_LOGIN_PASSWORD: "password"
+  DEFAULT_USER_ACCOUNT: "1033623433"
+  DEFAULT_USER_USERNAME: "testuser"
+  DEFAULT_USER_NAME: "Eve"
+  DEFAULT_DEPOSIT_ACCOUNT: "9099791699"
+  DEFAULT_DEPOSIT_ROUTING: "808889588"
+  DEFAULT_DEPOSIT_LABEL: "External Bank"
+  DEFAULT_CONTACT_ACCOUNT_A: "1044226144"
+  DEFAULT_CONTACT_NAME_A: "Alice"
+  DEFAULT_CONTACT_ACCOUNT_B: "1055757655"
+  DEFAULT_CONTACT_NAME_B: "Bob"

--- a/kubernetes-manifests-asm/contacts.yaml
+++ b/kubernetes-manifests-asm/contacts.yaml
@@ -1,0 +1,106 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: contacts
+spec:
+  selector:
+    matchLabels:
+      app: contacts
+  template:
+    metadata:
+      labels:
+        app: contacts
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: contacts
+        image: gcr.io/bank-of-anthos/contacts:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: accounts-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: contacts
+spec:
+  type: ClusterIP
+  selector:
+    app: contacts
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: contacts
+spec:
+  hosts:
+  - contacts
+  http:
+  - route:
+    - destination:
+        host: contacts
+        subset: v0-2-0
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: contacts-destination
+spec:
+  host: contacts
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0

--- a/kubernetes-manifests-asm/frontend.yaml
+++ b/kubernetes-manifests-asm/frontend.yaml
@@ -1,0 +1,89 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: front
+        image: gcr.io/bank-of-anthos/frontend:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        - name: DEFAULT_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: default-data-config
+              key: DEFAULT_USER_USERNAME
+        - name: DEFAULT_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: default-data-config
+              key: DEFAULT_LOGIN_PASSWORD
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: service-api-config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080

--- a/kubernetes-manifests-asm/ledger-db.yaml
+++ b/kubernetes-manifests-asm/ledger-db.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       labels:
         app: ledger-db
+        version: v0.2.0
     spec:
       containers:
         - name: postgres
@@ -80,3 +81,30 @@ spec:
   - name: postgres
     port: 5432
     targetPort: 5432
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ledger-db
+spec:
+  hosts:
+  - ledger-db
+  tcp:
+  - route:
+    - destination:
+        host: ledger-db
+        subset: v0-2-0
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: ledger-db-destination
+spec:
+  host: ledger-db
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0

--- a/kubernetes-manifests-asm/ledger-db.yaml
+++ b/kubernetes-manifests-asm/ledger-db.yaml
@@ -1,0 +1,82 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: ledger-db
+spec:
+  serviceName: "ledger-db"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ledger-db
+  template:
+    metadata:
+      labels:
+        app: ledger-db
+    spec:
+      containers:
+        - name: postgres
+          image: gcr.io/bank-of-anthos/ledger-db:latest
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: environment-config
+            - configMapRef:
+                name: ledger-db-config
+            - configMapRef:
+                name: default-data-config
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: postgresdb
+              mountPath: /var/lib/postgresql/data
+              subPath: postgres
+      volumes:
+        - name: postgresdb
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ledger-db-config
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: postgresdb
+  POSTGRES_USER: admin
+  POSTGRES_PASSWORD: password
+  SPRING_DATASOURCE_URL: jdbc:postgresql://ledger-db:5432/postgresdb
+  SPRING_DATASOURCE_USERNAME: admin # should match POSTGRES_USER
+  SPRING_DATASOURCE_PASSWORD: password # should match POSTGRES_PASSWORD
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ledger-db
+spec:
+  type: ClusterIP
+  selector:
+    app: ledger-db
+  ports:
+  - name: postgres
+    port: 5432
+    targetPort: 5432

--- a/kubernetes-manifests-asm/ledger-writer.yaml
+++ b/kubernetes-manifests-asm/ledger-writer.yaml
@@ -1,0 +1,112 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ledgerwriter
+spec:
+  selector:
+    matchLabels:
+      app: ledgerwriter
+  template:
+    metadata:
+      labels:
+        app: ledgerwriter
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: writer
+        image: gcr.io/bank-of-anthos/ledgerwriter:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+         # tell Java to obey container memory limits
+        - name: JVM_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: service-api-config
+        # add ledger-db credentials from ConfigMap
+        - configMapRef:
+            name: ledger-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ledgerwriter
+spec:
+  type: ClusterIP
+  selector:
+    app: ledgerwriter
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ledgerwriter
+spec:
+  hosts:
+  - ledgerwriter
+  http:
+  - route:
+    - destination:
+        host: ledgerwriter
+        subset: v0-2-0
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: ledgerwriter-destination
+spec:
+  host: ledgerwriter
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0

--- a/kubernetes-manifests-asm/loadgenerator.yaml
+++ b/kubernetes-manifests-asm/loadgenerator.yaml
@@ -1,0 +1,46 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgenerator
+spec:
+  selector:
+    matchLabels:
+      app: loadgenerator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: loadgenerator
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      terminationGracePeriodSeconds: 5
+      restartPolicy: Always
+      containers:
+      - name: main
+        image: gcr.io/bank-of-anthos/loadgenerator:latest
+        env:
+        - name: FRONTEND_ADDR
+          value: "frontend:80"
+        - name: USERS
+          value: "5"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi

--- a/kubernetes-manifests-asm/transaction-history.yaml
+++ b/kubernetes-manifests-asm/transaction-history.yaml
@@ -1,0 +1,126 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transactionhistory
+spec:
+  selector:
+    matchLabels:
+      app: transactionhistory
+  template:
+    metadata:
+      labels:
+        app: transactionhistory
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: history
+        image: gcr.io/bank-of-anthos/transactionhistory:latest
+        volumeMounts:
+        - name: publickey
+          mountPath: "/root/.ssh"
+          readOnly: true
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        - name: POLL_MS
+          value: "100"
+        - name: CACHE_SIZE
+          value: "1000"
+        - name: CACHE_MINUTES
+          value: "60"
+        - name: HISTORY_LIMIT
+          value: "100"
+          # tell Java to obey container memory limits
+        - name: JVM_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        #- name: EXTRA_LATENCY_MILLIS
+        #  value: "5000"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        # add ledger-db credentials from ConfigMap
+        - configMapRef:
+            name: ledger-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: transactionhistory
+spec:
+  type: ClusterIP
+  selector:
+    app: transactionhistory
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: transactionhistory
+spec:
+  hosts:
+  - transactionhistory
+  http:
+  - route:
+    - destination:
+        host: transactionhistory
+        subset: v0-2-0
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: transactionhistory-destination
+spec:
+  host: transactionhistory
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0

--- a/kubernetes-manifests-asm/userservice.yaml
+++ b/kubernetes-manifests-asm/userservice.yaml
@@ -1,0 +1,117 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: userservice
+spec:
+  selector:
+    matchLabels:
+      app: userservice
+  template:
+    metadata:
+      labels:
+        app: userservice
+        version: v0.2.0
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: userservice
+        image: gcr.io/bank-of-anthos/userservice:latest
+        volumeMounts:
+        - name: keys
+          mountPath: "/root/.ssh"
+          readOnly: true
+        ports:
+        - name: http-server
+          containerPort: 8080
+        env:
+        - name: VERSION
+          value: "v0.2.0"
+        - name: PORT
+          value: "8080"
+        - name: TOKEN_EXPIRY_SECONDS
+          value: "3600"
+        - name: PRIV_KEY_PATH
+          value: "/root/.ssh/privatekey"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: accounts-db-config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+      volumes:
+      - name: keys
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key
+            path: privatekey
+          - key: jwtRS256.key.pub
+            path: publickey
+
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: userservice
+spec:
+  type: ClusterIP
+  selector:
+    app: userservice
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: userservice
+spec:
+  hosts:
+  - userservice
+  http:
+  - route:
+    - destination:
+        host: userservice
+        subset: v0-2-0
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: userservice-destination
+spec:
+  host: userservice
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+  - name: v0-2-0
+    labels:
+      version: v0.2.0

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -30,6 +30,8 @@ Implemented in Python with Flask.
   - a string to pre-populate the "username" field. Optional
 - `DEFAULT_PASSWORD`
   - a string to pre-populate the "password" field. Optional
+-  `BANK_NAME`
+  - a string that will be shown in the navbar to indicate the name of the bank. Optional
 
 - ConfigMap `environment-config`:
   - `LOCAL_ROUTING_NUM`

--- a/src/frontend/flask_server.py
+++ b/src/frontend/flask_server.py
@@ -103,7 +103,8 @@ def home():
                            name=display_name,
                            account_id=account_id,
                            contacts=contacts,
-                           message=request.args.get('msg', None))
+                           message=request.args.get('msg', None),
+                           bank_name=os.getenv('BANK_NAME', 'Bank of Anthos'))
 
 
 def _populate_contact_labels(account_id, transactions, contacts):
@@ -284,7 +285,8 @@ def login_page():
     return render_template('login.html',
                            message=request.args.get('msg', None),
                            default_user=os.getenv('DEFAULT_USERNAME', ''),
-                           default_password=os.getenv('DEFAULT_PASSWORD', ''))
+                           default_password=os.getenv('DEFAULT_PASSWORD', ''),
+                           bank_name=os.getenv('BANK_NAME', 'Bank of Anthos'))
 
 
 @APP.route('/login', methods=['POST'])
@@ -329,7 +331,8 @@ def signup_page():
     if verify_token(token):
         # already authenticated
         return redirect(url_for('home'))
-    return render_template('signup.html')
+    return render_template('signup.html',
+                           bank_name=os.getenv('BANK_NAME', 'Bank of Anthos'))
 
 
 @APP.route("/signup", methods=['POST'])

--- a/src/frontend/templates/index.html
+++ b/src/frontend/templates/index.html
@@ -19,7 +19,7 @@ limitations under the License.
       <meta charset="utf-8">
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-      <title>Bank of Anthos</title>
+      <title>{{ bank_name }}</title>
       <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
       <link rel="stylesheet" href="https://unpkg.com/bootstrap-material-design@4.1.1/dist/css/bootstrap-material-design.min.css" integrity="sha384-wXznGJNEXNG1NFsbm0ugrLFMQPWswR3lds2VeinahP8N0zJw9VWSopbjv2x7WCvX" crossorigin="anonymous">
       <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -31,7 +31,7 @@ limitations under the License.
         <nav class="navbar navbar-expand-lg navbar-top">
           <div class="container">
             <a class="navbar-brand">
-              Bank of Anthos
+              {{ bank_name }}
             </a>
             <button type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation" class="navbar-toggler navbar-toggler-right">
               <span class="material-icons">menu</span>

--- a/src/frontend/templates/login.html
+++ b/src/frontend/templates/login.html
@@ -19,7 +19,7 @@ limitations under the License.
       <meta charset="utf-8">
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-      <title>Bank of Anthos</title>
+      <title>{{ bank_name }}</title>
       <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
       <link rel="stylesheet" href="https://unpkg.com/bootstrap-material-design@4.1.1/dist/css/bootstrap-material-design.min.css" integrity="sha384-wXznGJNEXNG1NFsbm0ugrLFMQPWswR3lds2VeinahP8N0zJw9VWSopbjv2x7WCvX" crossorigin="anonymous">
       <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -31,7 +31,7 @@ limitations under the License.
         <nav class="navbar navbar-expand-lg navbar-top">
           <div class="container">
             <a class="navbar-brand">
-              Bank of Anthos
+              {{ bank_name }}
             </a>
           </div>
         </nav>

--- a/src/frontend/templates/signup.html
+++ b/src/frontend/templates/signup.html
@@ -19,7 +19,7 @@ limitations under the License.
       <meta charset="utf-8">
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-      <title>Bank of Anthos</title>
+      <title>{{ bank_name }}</title>
       <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
       <link rel="stylesheet" href="https://unpkg.com/bootstrap-material-design@4.1.1/dist/css/bootstrap-material-design.min.css" integrity="sha384-wXznGJNEXNG1NFsbm0ugrLFMQPWswR3lds2VeinahP8N0zJw9VWSopbjv2x7WCvX" crossorigin="anonymous">
       <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -31,7 +31,7 @@ limitations under the License.
         <nav class="navbar navbar-expand-lg navbar-top">
           <div class="container">
             <a class="navbar-brand">
-              Bank of Anthos
+              {{ bank_name }}
             </a>
           </div>
         </nav>


### PR DESCRIPTION
This Pull Request is to extend the Bank of Anthos demo and implement a deployment option that works with Anthos Service Mesh/Istio.

Key changes are as follows:
* Implements a new alternative set of manifests at `/kubernetes-manifests-asm` that deploy the Bank of Anthos with the appropriate ASM Resources (Gateway and Virtual Service instead of Service w/ LoadBalancer, Virtual Service and DestinationRule for all of the BoA components) - See `./kubernetes-manifests-asm/README.md` for a full list of differences between the standard manifests and the ASM manifests.
* Updates the existing documentation to reflect that there is an option to deploy with ASM (see `./kubernetes-manifests-asm/README.md` & `./README.md`
* Implements some examples of how you can utilise ASM with the Bank of Anthos - including Fault Injection and deploying a new version and Traffic Shifting. More examples will follow in a subsequent PR.
* Updates the `src/frontend` application to accept a new environment variable `BANK_NAME` which is shown in the NavBar of all pages. This is used as part of the example when deploying a new version of the application. It defaults to the existing `Bank of Anthos` value if unset.

Happy to make any changes and discuss the proposed changes here.
