### PR TITLE
Fixes loadgenerator not finishing signup

### DIFF
--- a/src/frontend/flask_server.py
+++ b/src/frontend/flask_server.py
@@ -496,7 +496,7 @@ APP.config["CONTACTS_URI"] = 'http://{}/contacts'.format(
     os.environ.get('CONTACTS_API_ADDR'))
 APP.config['PUBLIC_KEY'] = open(os.environ.get('PUB_KEY_PATH'), 'r').read()
 APP.config['LOCAL_ROUTING'] = os.getenv('LOCAL_ROUTING_NUM')
-APP.config['BACKEND_TIMEOUT'] = 3  # timeout in seconds for calls to the backend
+APP.config['BACKEND_TIMEOUT'] = 4  # timeout in seconds for calls to the backend
 APP.config['TOKEN_NAME'] = 'token'
 APP.config['TIMESTAMP_FORMAT'] = '%Y-%m-%dT%H:%M:%S.%f%z'
 APP.config['SCHEME'] = os.environ.get('SCHEME', 'http')

--- a/src/loadgenerator/locustfile.py
+++ b/src/loadgenerator/locustfile.py
@@ -21,7 +21,7 @@ Exercises the frontend endpoints for the system
 import json
 import logging
 from string import ascii_letters, digits
-from random import randint, random, choice, choices
+from random import randint, random, choice
 
 from locust import HttpLocust, TaskSet, TaskSequence, task, seq_task, between
 
@@ -62,7 +62,7 @@ def generate_username():
     generates random 15 character
     alphanumeric username
     """
-    return ''.join(choices(ascii_letters + digits, k=15))
+    return ''.join(choice(ascii_letters + digits) for _ in range(15))
 class AllTasks(TaskSequence):
     """
     wrapper for UnauthenticatedTasks and AuthenticatedTasks sets

--- a/src/loadgenerator/locustfile.py
+++ b/src/loadgenerator/locustfile.py
@@ -20,8 +20,8 @@ Exercises the frontend endpoints for the system
 
 import json
 import logging
-from random import randint, random, choice
-import uuid
+from string import ascii_letters, digits
+from random import randint, random, choice, choices
 
 from locust import HttpLocust, TaskSet, TaskSequence, task, seq_task, between
 
@@ -57,6 +57,12 @@ def signup_helper(locust, username):
             response.failure("login failed")
         return found_token
 
+def generate_username():
+    """
+    generates random 15 character
+    alphanumeric username
+    """
+    return ''.join(choices(ascii_letters + digits, k=15))
 class AllTasks(TaskSequence):
     """
     wrapper for UnauthenticatedTasks and AuthenticatedTasks sets
@@ -95,7 +101,7 @@ class AllTasks(TaskSequence):
             on success, exits UnauthenticatedTasks
             """
             # sign up
-            new_username = str(uuid.uuid4())
+            new_username = generate_username()
             success = signup_helper(self, new_username)
             if success:
                 # go to AuthenticatedTasks
@@ -145,7 +151,7 @@ class AllTasks(TaskSequence):
                 amount = random() * 1000
             transaction = {"account_num": choice(TRANSACTION_ACCT_LIST),
                            "amount": amount,
-                           "uuid": str(uuid.uuid4())}
+                           "uuid": generate_username()}
             with self.client.post("/payment",
                                   data=transaction,
                                   catch_response=True) as response:
@@ -163,7 +169,7 @@ class AllTasks(TaskSequence):
                          "routing_num":"111111111"}
             transaction = {"account": json.dumps(acct_info),
                            "amount": amount,
-                           "uuid": str(uuid.uuid4())}
+                           "uuid": generate_username()}
             with self.client.post("/deposit",
                                   data=transaction,
                                   catch_response=True) as response:


### PR DESCRIPTION
This PR fixes #267, this uses a random generation of 15 character alphanumeric string in order to satisfy username constraints specified by #172. 

The downside of replacing the uuid creation is that we now have a probability of collisions, but since we have 62 total alphanumeric characters and a 15 character string, theres a 1/62^15 chance of collision and the number of usernames the `loadgenerator` would need to create to even get a 1% probability of collisions is > 0.01* 62^15 = 7.68*10^24. Also increased backend timeout since the userservice would finish the user creation but the frontend timeout would end just after.

Before:
![image](https://user-images.githubusercontent.com/10320227/87723265-94d94200-c787-11ea-8234-68b425fc1fc0.png)

After:
![image](https://user-images.githubusercontent.com/10320227/87723681-25b01d80-c788-11ea-901e-f1eeb04f4873.png)
