### PR TITLE
Fix cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -30,10 +30,10 @@ jobs:
         run: |
           gcloud container clusters get-credentials $PR_CLUSTER \
               --zone $ZONE --project $PROJECT_ID
-          PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
           NAMESPACE="pr${PR_NUMBER}"
           kubectl delete namespace $NAMESPACE
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           PR_CLUSTER: ${{ secrets.PR_CLUSTER_2 }}
           ZONE: ${{ secrets.PR_CLUSTER_2_ZONE }}
+          PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           gcloud container clusters get-credentials $PR_CLUSTER \
               --zone $ZONE --project $PROJECT_ID
-                  PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
           NAMESPACE="pr${PR_NUMBER}"
           kubectl delete namespace $NAMESPACE
         env:


### PR DESCRIPTION
Fixes the issue where due to the closing of PR and deletion of branch the cleanup workflow breaks due the `GITHUB_REF` environment variable referring to the default master branch after deletion of branch. Tested by closing this PR and deleted branch associated with this PR. Based on: https://stackoverflow.com/questions/62779643/how-to-extract-branch-name-on-delete-event-github-actions