### PR TITLE
Convert Python services to use raw SQL instead of the SQLAlchemy ORM

### DIFF
--- a/src/accounts-db/initdb/0-accounts-schema.sql
+++ b/src/accounts-db/initdb/0-accounts-schema.sql
@@ -28,8 +28,8 @@ CREATE TABLE IF NOT EXISTS users (
   ssn CHAR(11) NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_users_accountid ON users (accountid);
-CREATE INDEX IF NOT EXISTS idx_users_username ON users (username);
+CREATE INDEX IF NOT EXISTS idx_users_accountid ON users USING HASH (accountid);
+CREATE INDEX IF NOT EXISTS idx_users_username ON users USING HASH (username);
 
 
 
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS contacts (
   account_num CHAR(10) NOT NULL,
   routing_num CHAR(9) NOT NULL,
   is_external BOOLEAN NOT NULL,
-  FOREIGN KEY (username) REFERENCES users(username)
+  CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES users(username) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_contacts_username ON contacts (username);
+CREATE INDEX IF NOT EXISTS idx_contacts_username ON contacts USING HASH (username);

--- a/src/contacts/contacts.py
+++ b/src/contacts/contacts.py
@@ -33,7 +33,7 @@ from opentelemetry.ext.flask import FlaskInstrumentor
 from opentelemetry.propagators import set_global_httptextformat
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
-from sqlalchemy.exc import OperationalError, SQLAlchemyError
+from psycopg2 import Error
 from db import ContactsDb
 
 
@@ -84,7 +84,7 @@ def create_app():
         except (PermissionError, jwt.exceptions.InvalidTokenError) as err:
             app.logger.error("Error retrieving contacts list: %s", str(err))
             return "authentication denied", 401
-        except SQLAlchemyError as err:
+        except Error as err:
             app.logger.error("Error retrieving contacts list: %s", str(err))
             return "failed to retrieve contacts list", 500
 
@@ -142,7 +142,7 @@ def create_app():
         except ValueError as err:
             app.logger.error("Error adding contact: %s", str(err))
             return str(err), 409
-        except SQLAlchemyError as err:
+        except Error as err:
             app.logger.error("Error adding contact: %s", str(err))
             return "failed to add contact", 500
 
@@ -218,7 +218,7 @@ def create_app():
     # Configure database connection
     try:
         contacts_db = ContactsDb(os.environ.get("ACCOUNTS_DB_URI"), app.logger)
-    except OperationalError:
+    except Error:
         app.logger.critical("database connection failed")
         sys.exit(1)
     return app

--- a/src/contacts/db.py
+++ b/src/contacts/db.py
@@ -46,8 +46,9 @@ class ContactsDb:
         with psycopg2.connect(self.uri) as conn:
             with conn.cursor() as curs:
                 query = sql.SQL("INSERT INTO "
-                    "contacts(username, label, account_num, routing_num, "
-                    "is_external) VALUES (%s, %s, %s, %s, %s)")
+                                "contacts(username, label, account_num, "
+                                "routing_num, is_external) "
+                                "VALUES (%s, %s, %s, %s, %s)")
                 self.logger.debug("QUERY: %s", str(query))
                 curs.execute(query, (
                     contact.get('username'),
@@ -65,12 +66,11 @@ class ContactsDb:
                 [ {'label': contact1, ...}, {'label': contact2, ...}, ...]
         Raises: psycopg2.Error  if there was an issue with the database
         """
-        self.logger.info("db get: {}".format(t))
         contacts = list()
         with psycopg2.connect(self.uri) as conn:
             with conn.cursor() as curs:
                 query = sql.SQL("SELECT * FROM contacts "
-                    "WHERE contacts.username = %s")
+                                "WHERE contacts.username = %s")
                 self.logger.debug("QUERY: %s", str(query))
                 curs.execute(query, (username,))
 

--- a/src/contacts/db.py
+++ b/src/contacts/db.py
@@ -17,7 +17,6 @@ db manages interactions with the underlying database
 """
 
 import logging
-import time
 import psycopg2
 from psycopg2 import sql
 from opentelemetry.ext.psycopg2 import Psycopg2Instrumentor
@@ -25,8 +24,8 @@ from opentelemetry.ext.psycopg2 import Psycopg2Instrumentor
 
 class ContactsDb:
     """
-    ContactsDb provides a set of helper functions over SQLAlchemy
-    to handle db operations for contact service.
+    ContactsDb provides a set of helper functions
+    to handle db operations for the contact service.
     """
 
     def __init__(self, uri, logger=logging):
@@ -36,18 +35,19 @@ class ContactsDb:
         # Set up tracing autoinstrumentation with open telemetry
         Psycopg2Instrumentor().instrument()
 
+
     def add_contact(self, contact):
         """Add a contact under the specified username.
 
         Params: user - a key/value dict of attributes describing a new contact
                     {'username': username, 'label': label, ...}
-        Raises: SQLAlchemyError if there was an issue with the database
+        Raises: psycopg2.Error  if there was an issue with the database
         """
         with psycopg2.connect(self.uri) as conn:
             with conn.cursor() as curs:
                 query = sql.SQL("INSERT INTO "
-                    "contacts(username, label, account_num, routing_num, is_external) "
-                    "VALUES (%s, %s, %s, %s, %s)")
+                    "contacts(username, label, account_num, routing_num, "
+                    "is_external) VALUES (%s, %s, %s, %s, %s)")
                 self.logger.debug("QUERY: %s", str(query))
                 curs.execute(query, (
                     contact.get('username'),
@@ -56,35 +56,32 @@ class ContactsDb:
                     contact.get('routing_num'),
                     contact.get('is_external')))
 
+
     def get_contacts(self, username):
         """Get a list of contacts for the specified username.
 
         Params: username - the username of the user
         Return: a list of contacts in the form of key/value attribute dicts,
                 [ {'label': contact1, ...}, {'label': contact2, ...}, ...]
-        Raises: SQLAlchemyError if there was an issue with the database
+        Raises: psycopg2.Error  if there was an issue with the database
         """
-        t = time.time()
         self.logger.info("db get: {}".format(t))
         contacts = list()
         with psycopg2.connect(self.uri) as conn:
-            self.logger.debug("db connect: {}".format(time.time() - t))
             with conn.cursor() as curs:
-                query = sql.SQL("SELECT * FROM contacts WHERE contacts.username = %s")
+                query = sql.SQL("SELECT * FROM contacts "
+                    "WHERE contacts.username = %s")
                 self.logger.debug("QUERY: %s", str(query))
-                result = curs.execute(query, (username,))
-                self.logger.debug("db execute: {}".format(time.time() - t))
+                curs.execute(query, (username,))
 
-        if result is not None:
-            for row in result:
-                contact = {
-                    "label": row["label"],
-                    "account_num": row["account_num"],
-                    "routing_num": row["routing_num"],
-                    "is_external": row["is_external"],
-                }
-                contacts.append(contact)
+                for row in curs:
+                    contact = {
+                        "label": row["label"],
+                        "account_num": row["account_num"],
+                        "routing_num": row["routing_num"],
+                        "is_external": row["is_external"],
+                    }
+                    contacts.append(contact)
 
         self.logger.debug("RESULT: Fetched %d contacts.", len(contacts))
-        self.logger.debug("db return: {}".format(time.time() - t))
         return contacts

--- a/src/contacts/requirements.in
+++ b/src/contacts/requirements.in
@@ -4,7 +4,6 @@ cryptography==2.9
 gunicorn==20.0.4
 bleach==3.1.4
 psycopg2-binary==2.7.7
-sqlalchemy==1.3.16
 opentelemetry-sdk==0.10b0
 opentelemetry-exporter-cloud-trace==0.10b0
 opentelemetry-ext-flask==0.10b0

--- a/src/contacts/requirements.in
+++ b/src/contacts/requirements.in
@@ -3,9 +3,9 @@ pyjwt==1.7.1
 cryptography==2.9
 gunicorn==20.0.4
 bleach==3.1.4
-psycopg2==2.7.7
+psycopg2-binary==2.7.7
 sqlalchemy==1.3.16
 opentelemetry-sdk==0.10b0
 opentelemetry-exporter-cloud-trace==0.10b0
 opentelemetry-ext-flask==0.10b0
-opentelemetry-ext-sqlalchemy==0.10b.0
+opentelemetry-ext-psycopg2==0.10b0

--- a/src/contacts/requirements.txt
+++ b/src/contacts/requirements.txt
@@ -23,15 +23,16 @@ idna==2.10                # via requests
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.1            # via flask
 markupsafe==1.1.1         # via jinja2
-opentelemetry-api==0.10b0  # via opentelemetry-exporter-cloud-trace, opentelemetry-ext-flask, opentelemetry-ext-sqlalchemy, opentelemetry-ext-wsgi, opentelemetry-instrumentation, opentelemetry-sdk
+opentelemetry-api==0.10b0  # via opentelemetry-exporter-cloud-trace, opentelemetry-ext-dbapi, opentelemetry-ext-flask, opentelemetry-ext-psycopg2, opentelemetry-ext-wsgi, opentelemetry-instrumentation, opentelemetry-sdk
 opentelemetry-exporter-cloud-trace==0.10b0  # via -r requirements.in
+opentelemetry-ext-dbapi==0.10b0  # via opentelemetry-ext-psycopg2
 opentelemetry-ext-flask==0.10b0  # via -r requirements.in
-opentelemetry-ext-sqlalchemy==0.10b.0  # via -r requirements.in
+opentelemetry-ext-psycopg2==0.10b0  # via -r requirements.in
 opentelemetry-ext-wsgi==0.10b0  # via opentelemetry-ext-flask
-opentelemetry-instrumentation==0.10b0  # via opentelemetry-ext-flask, opentelemetry-ext-sqlalchemy, opentelemetry-ext-wsgi
+opentelemetry-instrumentation==0.10b0  # via opentelemetry-ext-dbapi, opentelemetry-ext-flask, opentelemetry-ext-psycopg2, opentelemetry-ext-wsgi
 opentelemetry-sdk==0.10b0  # via -r requirements.in, opentelemetry-exporter-cloud-trace
 protobuf==3.12.2          # via google-api-core, googleapis-common-protos
-psycopg2==2.7.7           # via -r requirements.in
+psycopg2-binary==2.7.7    # via -r requirements.in, opentelemetry-ext-psycopg2
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.20           # via cffi
@@ -40,11 +41,11 @@ pytz==2020.1              # via google-api-core
 requests==2.24.0          # via google-api-core
 rsa==4.6                  # via google-auth
 six==1.14.0               # via bleach, cryptography, google-api-core, google-auth, grpcio, protobuf
-sqlalchemy==1.3.16        # via -r requirements.in, opentelemetry-ext-sqlalchemy
+sqlalchemy==1.3.16        # via -r requirements.in
 urllib3==1.25.9           # via requests
 webencodings==0.5.1       # via bleach
 werkzeug==1.0.1           # via flask
-wrapt==1.12.1             # via opentelemetry-ext-sqlalchemy, opentelemetry-instrumentation
+wrapt==1.12.1             # via opentelemetry-ext-dbapi, opentelemetry-ext-psycopg2, opentelemetry-instrumentation
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/src/contacts/requirements.txt
+++ b/src/contacts/requirements.txt
@@ -41,7 +41,6 @@ pytz==2020.1              # via google-api-core
 requests==2.24.0          # via google-api-core
 rsa==4.6                  # via google-auth
 six==1.14.0               # via bleach, cryptography, google-api-core, google-auth, grpcio, protobuf
-sqlalchemy==1.3.16        # via -r requirements.in
 urllib3==1.25.9           # via requests
 webencodings==0.5.1       # via bleach
 werkzeug==1.0.1           # via flask

--- a/src/userservice/db.py
+++ b/src/userservice/db.py
@@ -47,9 +47,11 @@ class UserDb:
         with psycopg2.connect(self.uri) as conn:
             with conn.cursor() as curs:
                 query = sql.SQL("INSERT INTO "
-                    "users(accountid, username, passhash, firstname, "
-                    "lastname, birthday, timezone, address, state, zip, ssn) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)")
+                                "users(accountid, username, passhash, "
+                                "firstname, lastname, birthday, timezone, "
+                                "address, state, zip, ssn) "
+                                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, "
+                                "%s, %s)")
                 self.logger.debug("QUERY: %s", str(query))
                 curs.execute(query, (
                     user.get('accountid'),
@@ -76,7 +78,7 @@ class UserDb:
         with psycopg2.connect(self.uri) as conn:
             with conn.cursor() as curs:
                 query = sql.SQL("SELECT * FROM users "
-                    "WHERE users.accountid = %s")
+                                "WHERE users.accountid = %s")
                 self.logger.debug("QUERY: %s", str(query))
                 while accountid is None:
                     accountid = str(random.randint(1e9, (1e10 - 1)))
@@ -103,7 +105,7 @@ class UserDb:
         with psycopg2.connect(self.uri) as conn:
             with conn.cursor() as curs:
                 query = sql.SQL("SELECT * FROM users "
-                    "WHERE users.username = %s")
+                                "WHERE users.username = %s")
                 self.logger.debug("QUERY: %s", str(query))
                 curs.execute(query, (username,))
 

--- a/src/userservice/db.py
+++ b/src/userservice/db.py
@@ -18,72 +18,78 @@ db manages interactions with the underlying database
 
 import logging
 import random
-from opentelemetry.ext.sqlalchemy import SQLAlchemyInstrumentor
-from sqlalchemy import create_engine, MetaData, Table, Column, String, Date, LargeBinary
+import psycopg2
+from psycopg2 import sql
+from opentelemetry.ext.psycopg2 import Psycopg2Instrumentor
 
 
 class UserDb:
     """
-    UserDb provides a set of helper functions over SQLAlchemy
-    to handle db operations for userservice
+    UserDb provides a set of helper functions
+    to handle db operations for the userservice
     """
 
     def __init__(self, uri, logger=logging):
-        self.engine = create_engine(uri)
+        self.uri = uri
         self.logger = logger
-        self.users_table = Table(
-            'users',
-            MetaData(self.engine),
-            Column('accountid', String, primary_key=True),
-            Column('username', String, unique=True, nullable=False),
-            Column('passhash', LargeBinary, nullable=False),
-            Column('firstname', String, nullable=False),
-            Column('lastname', String, nullable=False),
-            Column('birthday', Date, nullable=False),
-            Column('timezone', String, nullable=False),
-            Column('address', String, nullable=False),
-            Column('state', String, nullable=False),
-            Column('zip', String, nullable=False),
-            Column('ssn', String, nullable=False),
-        )
 
-        # Set up tracing autoinstrumentation for sqlalchemy
-        SQLAlchemyInstrumentor().instrument(
-            engine=self.engine,
-            service='users',
-        )
+        # Set up tracing autoinstrumentation with open telemetry
+        Psycopg2Instrumentor().instrument()
+
 
     def add_user(self, user):
         """Add a user to the database.
 
         Params: user - a key/value dict of attributes describing a new user
                     {'username': username, 'password': password, ...}
-        Raises: SQLAlchemyError if there was an issue with the database
+        Raises: psycopg2.Error  if there was an issue with the database
         """
-        statement = self.users_table.insert().values(user)
-        self.logger.debug('QUERY: %s', str(statement))
-        with self.engine.connect() as conn:
-            conn.execute(statement)
+        with psycopg2.connect(self.uri) as conn:
+            with conn.cursor() as curs:
+                query = sql.SQL("INSERT INTO "
+                    "users(accountid, username, passhash, firstname, "
+                    "lastname, birthday, timezone, address, state, zip, ssn) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)")
+                self.logger.debug("QUERY: %s", str(query))
+                curs.execute(query, (
+                    user.get('accountid'),
+                    user.get('username'),
+                    user.get('passhash'),
+                    user.get('firstname'),
+                    user.get('lastname'),
+                    user.get('birthday'),
+                    user.get('timezone'),
+                    user.get('address'),
+                    user.get('state'),
+                    user.get('zip'),
+                    user.get('ssn')))
+
 
     def generate_accountid(self):
-        """Generates a globally unique alphanumerical accountid."""
+        """Generates a globally unique alphanumerical accountid.
+
+        Return: an alphanumerical accountid
+        Raises: psycopg2.Error  if there was an issue with the database
+        """
         self.logger.debug('Generating an account ID')
         accountid = None
-        with self.engine.connect() as conn:
-            while accountid is None:
-                accountid = str(random.randint(1e9, (1e10 - 1)))
+        with psycopg2.connect(self.uri) as conn:
+            with conn.cursor() as curs:
+                query = sql.SQL("SELECT * FROM users "
+                    "WHERE users.accountid = %s")
+                self.logger.debug("QUERY: %s", str(query))
+                while accountid is None:
+                    accountid = str(random.randint(1e9, (1e10 - 1)))
 
-                statement = self.users_table.select().where(
-                    self.users_table.c.accountid == accountid
-                )
-                self.logger.debug('QUERY: %s', str(statement))
-                result = conn.execute(statement).first()
-                # If there already exists an account, try again.
-                if result is not None:
-                    accountid = None
-                    self.logger.debug('RESULT: account ID already exists. Trying again')
+                    curs.execute(query, (accountid,))
+                    # If there already exists an account, try again.
+                    if curs.fetchone() is not None:
+                        accountid = None
+                        self.logger.debug('RESULT: account ID already exists. Trying again')
+
         self.logger.debug('RESULT: account ID generated.')
         return accountid
+
 
     def get_user(self, username):
         """Get user data for the specified username.
@@ -92,11 +98,16 @@ class UserDb:
         Return: a key/value dict of user attributes,
                 {'username': username, 'accountid': accountid, ...}
                 or None if that user does not exist
-        Raises: SQLAlchemyError if there was an issue with the database
+        Raises: psycopg2.Error  if there was an issue with the database
         """
-        statement = self.users_table.select().where(self.users_table.c.username == username)
-        self.logger.debug('QUERY: %s', str(statement))
-        with self.engine.connect() as conn:
-            result = conn.execute(statement).first()
+        with psycopg2.connect(self.uri) as conn:
+            with conn.cursor() as curs:
+                query = sql.SQL("SELECT * FROM users "
+                    "WHERE users.username = %s")
+                self.logger.debug("QUERY: %s", str(query))
+                curs.execute(query, (username,))
+
+                result = curs.fetchone()
+
         self.logger.debug('RESULT: fetched user data for %s', username)
         return dict(result) if result is not None else None

--- a/src/userservice/requirements.in
+++ b/src/userservice/requirements.in
@@ -4,9 +4,8 @@ cryptography==2.9
 gunicorn==20.0.4
 bcrypt==3.1.7
 bleach==3.1.4
-psycopg2==2.7.7
-sqlalchemy==1.3.16
+psycopg2-binary==2.7.7
 opentelemetry-sdk==0.10b0
 opentelemetry-exporter-cloud-trace==0.10b0
 opentelemetry-ext-flask==0.10b0
-opentelemetry-ext-sqlalchemy==0.10b.0
+opentelemetry-ext-psycopg2==0.10b0

--- a/src/userservice/requirements.txt
+++ b/src/userservice/requirements.txt
@@ -24,15 +24,16 @@ idna==2.10                # via requests
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.1            # via flask
 markupsafe==1.1.1         # via jinja2
-opentelemetry-api==0.10b0  # via opentelemetry-exporter-cloud-trace, opentelemetry-ext-flask, opentelemetry-ext-sqlalchemy, opentelemetry-ext-wsgi, opentelemetry-instrumentation, opentelemetry-sdk
+opentelemetry-api==0.10b0  # via opentelemetry-exporter-cloud-trace, opentelemetry-ext-dbapi, opentelemetry-ext-flask, opentelemetry-ext-psycopg2, opentelemetry-ext-wsgi, opentelemetry-instrumentation, opentelemetry-sdk
 opentelemetry-exporter-cloud-trace==0.10b0  # via -r requirements.in
+opentelemetry-ext-dbapi==0.10b0  # via opentelemetry-ext-psycopg2
 opentelemetry-ext-flask==0.10b0  # via -r requirements.in
-opentelemetry-ext-sqlalchemy==0.10b.0  # via -r requirements.in
+opentelemetry-ext-psycopg2==0.10b0  # via -r requirements.in
 opentelemetry-ext-wsgi==0.10b0  # via opentelemetry-ext-flask
-opentelemetry-instrumentation==0.10b0  # via opentelemetry-ext-flask, opentelemetry-ext-sqlalchemy, opentelemetry-ext-wsgi
+opentelemetry-instrumentation==0.10b0  # via opentelemetry-ext-dbapi, opentelemetry-ext-flask, opentelemetry-ext-psycopg2, opentelemetry-ext-wsgi
 opentelemetry-sdk==0.10b0  # via -r requirements.in, opentelemetry-exporter-cloud-trace
 protobuf==3.12.2          # via google-api-core, googleapis-common-protos
-psycopg2==2.7.7           # via -r requirements.in
+psycopg2-binary==2.7.7    # via -r requirements.in, opentelemetry-ext-psycopg2
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.20           # via cffi
@@ -41,11 +42,10 @@ pytz==2020.1              # via google-api-core
 requests==2.24.0          # via google-api-core
 rsa==4.6                  # via google-auth
 six==1.14.0               # via bcrypt, bleach, cryptography, google-api-core, google-auth, grpcio, protobuf
-sqlalchemy==1.3.16        # via -r requirements.in, opentelemetry-ext-sqlalchemy
 urllib3==1.25.9           # via requests
 webencodings==0.5.1       # via bleach
 werkzeug==1.0.1           # via flask
-wrapt==1.12.1             # via opentelemetry-ext-sqlalchemy, opentelemetry-instrumentation
+wrapt==1.12.1             # via opentelemetry-ext-dbapi, opentelemetry-ext-psycopg2, opentelemetry-instrumentation
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/src/userservice/userservice.py
+++ b/src/userservice/userservice.py
@@ -34,7 +34,7 @@ from opentelemetry.ext.flask import FlaskInstrumentor
 from opentelemetry.propagators import set_global_httptextformat
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
-from sqlalchemy.exc import OperationalError, SQLAlchemyError
+from psycopg2 import Error
 from db import UserDb
 
 
@@ -124,7 +124,7 @@ def create_app():
         except NameError as err:
             app.logger.error("Error creating new user: %s", str(err))
             return str(err), 409
-        except SQLAlchemyError as err:
+        except Error as err:
             app.logger.error("Error creating new user: %s", str(err))
             return 'failed to create user', 500
 
@@ -206,7 +206,7 @@ def create_app():
         except PermissionError as err:
             app.logger.error('Error logging in: %s', str(err))
             return str(err), 401
-        except SQLAlchemyError as err:
+        except Error as err:
             app.logger.error('Error logging in: %s', str(err))
             return 'failed to retrieve user information', 500
 

--- a/src/userservice/userservice.py
+++ b/src/userservice/userservice.py
@@ -245,7 +245,7 @@ def create_app():
     # Configure database connection
     try:
         users_db = UserDb(os.environ.get("ACCOUNTS_DB_URI"), app.logger)
-    except OperationalError:
+    except Error:
         app.logger.critical("users_db database connection failed")
         sys.exit(1)
     return app


### PR DESCRIPTION
Fixes #295.

Change summary:
- Update database calls in Python services (userservice, contactservice) to make raw SQL calls with psycopg2.

The SQLAlchemy ORM was adding an average of ~500ms in latency to every HTTP request for these backend services.