### PR TITLE
Fix venv --clear flag placement in ci-master.yaml

### DIFF
--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -71,7 +71,7 @@ jobs:
           echo "testing $SERVICE..."
           # save current working dir to memory and cd to src/$SERVICE
           pushd src/$SERVICE
-            python3 -m venv $HOME/venv-$SERVICE
+            python3 -m venv --clear $HOME/venv-$SERVICE
             source $HOME/venv-$SERVICE/bin/activate
             pip install -r tests/requirements-test.txt
             python -m pytest -v -p no:warnings
@@ -86,7 +86,7 @@ jobs:
           echo "testing $SERVICE..."
           # save current working dir to memory and cd to src/$SERVICE
           pushd src/$SERVICE
-            python3 -m venv --clear $HOME/venv-$SERVICE
+            python3 -m venv $HOME/venv-$SERVICE
             source $HOME/venv-$SERVICE/bin/activate
             pip install -r tests/requirements-test.txt
             python -m pytest --cov=./ tests/


### PR DESCRIPTION
--clear flag was placed in the code coverage section, not the python unit tests. 