### PR TITLE
Add screenshots to ci-master, update documentation

### DIFF
--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -157,4 +157,9 @@ jobs:
         sleep 60
     - name: Run UI tests (Cypress)
       run: |
-        docker run -t -v $PWD/.github/workflows/ui-tests:/e2e -w /e2e -e CYPRESS_baseUrl=http://$EXTERNAL_IP --network=host cypress/included:5.0.0 --env CI=true
+        docker run -t -v $PWD/.github/workflows/ui-tests:/e2e -w /e2e -e CYPRESS_baseUrl=http://$EXTERNAL_IP -u node cypress/included:5.0.0 
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+          name: cypress-screenshots
+          path: ${{ github.workspace }}/.github/workflows/ui-tests/cypress/screenshots

--- a/.github/workflows/ui-tests/README.md
+++ b/.github/workflows/ui-tests/README.md
@@ -51,7 +51,7 @@ make test-e2e E2E_FLAGS="--spec cypress/integration/<test-file>.js"
 ```console
 docker run -it -v ${E2E_PATH}:/e2e -w /e2e \
  -e CYPRESS_baseUrl=${E2E_URL} -e CYPRESS_CI=false \
- cypress/included:4.3.0 --spec cypress/integration/<test-file>.js
+ cypress/included:5.0.0 --spec cypress/integration/<test-file>.js
 ```
 
 ### Filtering tests with `.only()` and `.skip()`
@@ -60,4 +60,4 @@ The `.only()` and `.skip()` functions can be appended to either single tests or 
 
 ### Screenshots
 
-Screenshots are enabled by passing the environment variable `CI=false`.  When running tests locally, failing tests will store screenshots in the `cypress/screenshots` directory. These are helpful when debugging tests.  [Read more about them here](https://docs.cypress.io/guides/guides/screenshots-and-videos.html#Screenshots).
+Failing tests will store screenshots in the `cypress/screenshots` directory (locally and CI) and uploaded as an [artifact to Github Actions](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts) after a failing build. These are helpful when debugging tests.  [Read more about them here](https://docs.cypress.io/guides/guides/screenshots-and-videos.html#Screenshots).


### PR DESCRIPTION
Fixes #93  .

Change summary:
- Cypress tests in ci-master were generating screenshots but running as root user.  This resulted in read-only files (Permission 0644) that could not be cleaned up by Github Actions and required manual deletion

![image](https://user-images.githubusercontent.com/12957039/94176337-ca1ba380-fe4c-11ea-8080-bb0aba5590a0.png)

- Updated Cypress tests to be same as ci-pr
- Updated docs with changes


Remaining issues / concerns:
