### PR TITLE
Fix null ProjectID error when running outside of GCP

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,10 @@
+# Running in Kubernetes Environments
+
+
+## GKE on GCP 
+
+Use the default instructions in the [README](/README.md). When Workload Identity is enabled, use the [Workload Identity instructions](/docs/workload-identity.md).  
+
+## AWS EKS 
+
+Use the default README instructions, but note that currently, metrics and trace export to Google Cloud Operations does not currently work. In the Deployment manifests, set `ENABLE_METRICS=false` and `ENABLE_TRACING=false` to prevent any pod crashes on startup.

--- a/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
+++ b/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
@@ -98,8 +98,8 @@ public class BalanceReaderApplication {
             @Override
             public String projectId() {
                 String id = MetadataConfig.getProjectId();
-                if(id == null) {
-                    id = ""; 
+                if (id == null) {
+                    id = "";
                 }
                 return id;
             }

--- a/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
+++ b/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
@@ -97,7 +97,11 @@ public class BalanceReaderApplication {
 
             @Override
             public String projectId() {
-                return MetadataConfig.getProjectId();
+                String id = MetadataConfig.getProjectId();
+                if(id == null) {
+                    id = ""; 
+                }
+                return id;
             }
 
             @Override

--- a/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
+++ b/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
@@ -103,7 +103,11 @@ public class LedgerWriterApplication {
 
             @Override
             public String projectId() {
-                return MetadataConfig.getProjectId();
+                String id = MetadataConfig.getProjectId();
+                if(id == null) {
+                    id = ""; 
+                }
+                return id;
             }
 
             @Override

--- a/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
+++ b/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
@@ -104,8 +104,8 @@ public class LedgerWriterApplication {
             @Override
             public String projectId() {
                 String id = MetadataConfig.getProjectId();
-                if(id == null) {
-                    id = ""; 
+                if (id == null) {
+                    id = "";
                 }
                 return id;
             }

--- a/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
+++ b/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
@@ -98,12 +98,12 @@ public class TransactionHistoryApplication {
             @Override
             public String projectId() {
                 String id = MetadataConfig.getProjectId();
-                if(id == null) {
-                    id = ""; 
+                if (id == null) {
+                    id = "";
                 }
                 return id;
             }
-            
+
             @Override
             public String get(String key) {
                 return null;

--- a/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
+++ b/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
@@ -97,9 +97,13 @@ public class TransactionHistoryApplication {
 
             @Override
             public String projectId() {
-                return MetadataConfig.getProjectId();
+                String id = MetadataConfig.getProjectId();
+                if(id == null) {
+                    id = ""; 
+                }
+                return id;
             }
-
+            
             @Override
             public String get(String key) {
                 return null;


### PR DESCRIPTION
Fixes #376 .

Change summary:
- Ensures that `projectId` is never set to null (instead, use the empty string) to prevent a Java startup crash that happens in non GCP (eg. AWS EKS) environments. The crash happens because when the pod runs outside of GKE/GCE, there is no GCE instance metadata, so calling the MetadataConfig.projectID function returns `null`. This causes Micrometer (metrics export) startup to fail. 


Remaining issues / concerns:
- Currently we have no mechanism or docs around enabling Google Cloud Trace/Monitoring export when the app itself is running in AWS. I filed an issue for this, I think we might just need Google App Default credentials mounted in as a secret. But the MetadataConfig still won't work outside of GCP. So the `projectID` won't be included in the trace metadata. Need to investigate.  