### PR TITLE
Fixing bug where balance isn't returned for accounts with no payments.

### DIFF
--- a/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/TransactionRepository.java
+++ b/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/TransactionRepository.java
@@ -28,10 +28,10 @@ public interface TransactionRepository
     extends CrudRepository<Transaction, Long> {
 
     @Query(value = "SELECT "
-        + " (SELECT SUM(AMOUNT) FROM TRANSACTIONS t "
-        + "     WHERE (TO_ACCT = ?1 AND TO_ROUTE = ?2)) - "
-        + " (SELECT SUM(AMOUNT) FROM TRANSACTIONS t "
-        + "     WHERE (FROM_ACCT = ?1 AND FROM_ROUTE = ?2))",
+    + "(SELECT SUM(AMOUNT) FROM TRANSACTIONS t "
+    + "     WHERE (TO_ACCT = ?1 AND TO_ROUTE = ?2)) - "
+    + " (SELECT COALESCE((SELECT SUM(AMOUNT) FROM TRANSACTIONS t "
+    + "     WHERE (FROM_ACCT = ?1 AND FROM_ROUTE = ?2)),0))",
         nativeQuery = true)
     Long findBalance(String accountNum, String routeNum);
 


### PR DESCRIPTION
Fixes # .
- Fixes issue when a new user is created, a deposit is made, but no payments.
- Scale or restart the balancereader pod and balance will always show as $---

Change summary:
- Uses coalesce in query to return 0 for payments if no records exist (instead of null).

Remaining issues / concerns:
