### PR TITLE
postgres:12-alpine

### DIFF
--- a/src/accounts-db/Dockerfile
+++ b/src/accounts-db/Dockerfile
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-FROM postgres:12
+FROM postgres:12-alpine
 
 # Files for initializing the database.
 COPY initdb/0-accounts-schema.sql /docker-entrypoint-initdb.d/0-accounts-schema.sql

--- a/src/ledger-db/Dockerfile
+++ b/src/ledger-db/Dockerfile
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM postgres:12
+FROM postgres:12-alpine
+
+# Need to get coreutils to get the date bash function working properly:
+RUN apk add --update coreutils && rm -rf /var/cache/apk/*
 
 COPY initdb/0_init_tables.sql /docker-entrypoint-initdb.d/0_init_tables.sql
 RUN chmod 755  /docker-entrypoint-initdb.d/0_init_tables.sql


### PR DESCRIPTION
- Update `accounts-db` and `ledger-db` container base images from `postgres:12` to `postgres:12-alpine`.
- `accounts-db`: from 109.05 MB to 59.15 MB
- `ledger-db`: from 109.05 MB to 59.14 MB

No issues with the current version but that's a way to get smaller as well as more secure (less surface) images for the databases. FYI: that's also what was done with the `redis` container on that repo: https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/kubernetes-manifests/redis.yaml#L30.