### PR TITLE
Fix Monolith GCE image to use public debian image

### DIFF
--- a/src/ledgermonolith/scripts/deploy-monolith.sh
+++ b/src/ledgermonolith/scripts/deploy-monolith.sh
@@ -62,8 +62,8 @@ gcloud compute instances create ledgermonolith-service \
     --project $PROJECT_ID \
     --zone $ZONE \
     --network default \
-    --image-family=debian-10-drawfork \
-    --image-project=eip-images \
+    --image-family=debian-10 \
+    --image-project=debian-cloud \
     --machine-type=n1-standard-1 \
     --scopes cloud-platform,storage-ro \
     --metadata gcs-bucket=${GCS_BUCKET},VmDnsSetting=ZonalPreferred \


### PR DESCRIPTION
Fixes #347 .

Change summary:
- Update GCE image for ledgermonolith to use `debian-10` instead of `debian-10-drawfork`
