### PR TITLE
Enable tracing for ledgermonolith services via k8 manifests

### DIFF
--- a/src/ledgermonolith/kubernetes-manifests/contacts.yaml
+++ b/src/ledgermonolith/kubernetes-manifests/contacts.yaml
@@ -38,6 +38,8 @@ spec:
           value: "v0.2.0"
         - name: PORT
           value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
         # Valid levels are debug, info, warning, error, critical.
         # If no valid level is set, will default to info.
         - name: LOG_LEVEL

--- a/src/ledgermonolith/kubernetes-manifests/frontend.yaml
+++ b/src/ledgermonolith/kubernetes-manifests/frontend.yaml
@@ -38,6 +38,8 @@ spec:
           value: "v0.2.0"
         - name: PORT
           value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
         - name: SCHEME
           value: "http"
          # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.

--- a/src/ledgermonolith/kubernetes-manifests/userservice.yaml
+++ b/src/ledgermonolith/kubernetes-manifests/userservice.yaml
@@ -41,6 +41,8 @@ spec:
           value: "v0.2.0"
         - name: PORT
           value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
         - name: TOKEN_EXPIRY_SECONDS
           value: "3600"
         - name: PRIV_KEY_PATH


### PR DESCRIPTION
Fixes #393  .

Change summary:
- Update ledgermonolith k8 manifests with ENABLE_TRACING = 'True'
