### PR TITLE
Update ledgermonolith to properly allow bank connections via firewall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ cluster: check-env
 		--project=${PROJECT_ID} --zone=${ZONE} \
 		--machine-type=e2-standard-4 --num-nodes=4 \
 		--enable-stackdriver-kubernetes --subnetwork=default \
-		--labels csm=
+		--tags=bank-of-anthos --labels csm=
 	skaffold run --default-repo=gcr.io/${PROJECT_ID} -l skaffold.dev/run-id=${CLUSTER}-${PROJECT_ID}-${ZONE}
 
 deploy: check-env

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ cd bank-of-anthos
 ZONE=us-central1-b
 gcloud beta container clusters create bank-of-anthos \
     --project=${PROJECT_ID} --zone=${ZONE} \
-    --machine-type=e2-standard-2 --num-nodes=4
+    --machine-type=e2-standard-2 --num-nodes=4 \
+		--enable-stackdriver-kubernetes --subnetwork=default \
+		--tags=bank-of-anthos --labels csm=
 ```
 
 4. **Deploy the demo JWT public key** to the cluster as a Secret. This key is used for user account creation and authentication. 

--- a/src/ledgermonolith/scripts/deploy-monolith.sh
+++ b/src/ledgermonolith/scripts/deploy-monolith.sh
@@ -82,9 +82,9 @@ if [ $? -ne 0 ]; then
       --project $PROJECT_ID \
       --network default \
       --allow tcp:8080 \
-      --source-tags monolith \
+      --source-tags bank-of-anthos \
       --target-tags monolith \
-      --description "Allow port 8080 access for monolith instances" \
+      --description "Allow port 8080 from bank-of-anthos to monolith VMs" \
       --quiet
 fi
 


### PR DESCRIPTION
Fixes #397  .

Change summary:
- Update bank-of-anthos cluster creation to add the `bank-of-anthos` network tag
- Update ledgermonolith to create a firewall rule allowing connections from `bank-of-anthos`

