### PR TITLE
Update ledgermonolith README with commands to run the full BoA app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ cluster: check-env
 		--machine-type=e2-standard-4 --num-nodes=4 \
 		--enable-stackdriver-kubernetes --subnetwork=default \
 		--labels csm=
-	skaffold run --default-repo=gcr.io/${PROJECT_ID} -l skaffold.dev/run-id=${CLUSTER}-${PROJECT_ID}-${ZONE}
 
 deploy: check-env
 	echo ${CLUSTER}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@
 
 .-PHONY: cluster deploy deploy-continuous logs checkstyle check-env
 
-ZONE=us-west1-a
 CLUSTER=bank-of-anthos
 E2E_PATH=${PWD}/.github/workflows/ui-tests/
 
@@ -35,6 +34,10 @@ deploy-continuous: check-env
 	skaffold dev --default-repo=gcr.io/${PROJECT_ID}
 
 monolith: check-env
+ifndef GCS_BUCKET
+	# GCS_BUCKET is undefined
+	# ATTENTION: Deployment proceeding with canonical pre-built monolith artifacts
+endif
 	# build and deploy Bank of Anthos along with a monolith backend service
 	mvn -f src/ledgermonolith/ package
 	src/ledgermonolith/scripts/build-artifacts.sh
@@ -43,11 +46,18 @@ monolith: check-env
 	(cd src/ledgermonolith; skaffold run --default-repo=gcr.io/${PROJECT_ID} -l skaffold.dev/run-id=${CLUSTER}-${PROJECT_ID}-${ZONE})
 
 monolith-build: check-env
+ifndef GCS_BUCKET
+	$(error GCS_BUCKET is undefined; specify a Google Cloud Storage bucket to store your build artifacts)
+endif
 	# build the artifacts for the ledgermonolith service 
 	mvn -f src/ledgermonolith/ package
 	src/ledgermonolith/scripts/build-artifacts.sh
 
 monolith-deploy: check-env
+ifndef GCS_BUCKET
+	# GCS_BUCKET is undefined
+	# ATTENTION: Deployment proceeding with canonical pre-built monolith artifacts
+endif
 	# deploy the ledgermonolith service to a GCE VM
 	src/ledgermonolith/scripts/deploy-monolith.sh
 

--- a/src/ledgermonolith/README.md
+++ b/src/ledgermonolith/README.md
@@ -70,6 +70,20 @@ Located in `init/ledgermonolith.env`
 - `scripts/build-artifacts.sh`: pushes build artifacts to Google Cloud Storage
 - `scripts/delete-artifacts.sh`: deletes build artifacts in Google Cloud Storage
 
+## Quickstart
+
+To deploy Bank of Anthos with a monolith service:
+
+```
+# In the root directory of the project repo
+export PROJECT_ID=<your-project-id>
+export ZONE=<your-gcp-zone>
+make monolith
+```
+
+Deploys the full Bank of Anthos application with a Java monolith service running
+on a Google Compute Engine VM and all other microservices running on Kubernetes.
+
 ## Deploying the Monolith 
 
 ### Option 1 - From Canonical Artifacts
@@ -112,6 +126,7 @@ PROJECT_ID=<your-project-id>
 ZONE=<your-gcp-zone>
 GCS_BUCKET=<your-gcs-bucket>
 make monolith-build
+make monolith-deploy
 ```
 
 #### Bash
@@ -164,14 +179,43 @@ Cloud network that also has the `monolith` network tag.
 6. If you see a version string like `v0.1.0`, the ledgermonolith is correctly serving HTTP requests
 
 
-## Deploying the Rest of the Services
+## Running Bank of Anthos with the Monolith
 
-Kubernetes manifests and a `skaffold.yaml` file are provided in the `kubernetes-manifests/` directory - containing the Python services (including the frontend), plus the accounts database. To deploy:
+To run the full Bank of Anthos application you also need to configure and deploy
+the microservices that are not part of the ledgermonolith service.
+This directory (`src/ledgermonolith`) includes a custom `skaffold.yaml` file and
+associated manifests in the `kubernetes-manifests` directory.
+These will deploy the other supporting microservices (including the frontend),
+plus the accounts database. To deploy, run the following commands from this
+directory:
 
-1. Populate the ConfigMap with your ledger monolith info (`config.yaml.template`). This tells the frontend how to reach the Java/ledger endpoints.
+1. Set environment variables
 
+```
+CLUSTER=<your-cluster-name>
+PROJECT_ID=<your-project-id>
+ZONE=<your-gcp-zone>
+```
 
-2. Run the following command from this directory: 
+2. Create the kubernetes cluster
+
+```
+gcloud container clusters create ${CLUSTER} \
+  --project=${PROJECT_ID} --zone=${ZONE} \
+  --machine-type=e2-standard-4 --num-nodes=4 \
+  --enable-stackdriver-kubernetes --subnetwork=default \
+  --labels csm=
+```
+
+3. Create a custom ConfigMap `kubernetes-manifests/config.yaml` based on the
+template file `kubernetes-manifests/config.yaml.template`. This tells the
+frontend how to reach the ledgermonolith API endpoints.
+
+```
+sed 's/\[PROJECT_ID\]/${PROJECT_ID}/g' kubernetes-manifests/config.yaml.template > kubernetes-manifests/config.yaml
+```
+
+4. Run the following command from this directory: 
 
 ```
 skaffold run --default-repo=gcr.io/${PROJECT_ID}/with-monolith

--- a/src/ledgermonolith/scripts/build-artifacts.sh
+++ b/src/ledgermonolith/scripts/build-artifacts.sh
@@ -26,6 +26,7 @@ if [[ -z ${PROJECT_ID} ]]; then
   exit 0
 elif [[ -z ${GCS_BUCKET} ]]; then
   echo "GCS_BUCKET must be set"
+	echo "Specify a Google Cloud Storage bucket to store your build artifacts"
   exit 0
 else
   echo "PROJECT_ID: ${PROJECT_ID}"

--- a/src/ledgermonolith/scripts/deploy-monolith.sh
+++ b/src/ledgermonolith/scripts/deploy-monolith.sh
@@ -33,7 +33,7 @@ fi
 if [[ -z ${GCS_BUCKET} ]]; then
   # If no bucket specified, default to canonical build artifacts
   GCS_BUCKET=bank-of-anthos
-  echo "GCS_BUCKET not specified, defaulting to canonical build artifacts..."
+  echo "GCS_BUCKET not specified, defaulting to canonical pre-built artifacts..."
 fi
 echo "GCS_BUCKET: ${GCS_BUCKET}"
 


### PR DESCRIPTION
Change summary:
- Adds explicit set of commands to deploy the ledgermonolith with the complete Bank of Anthos application
- Updates `make cluster` to only make the k8 cluster and not deploy the app images


Remaining issues / concerns:
Folks may be using `make cluster` as a one-click deployment option for the app.  That will no longer work here.