### PR TITLE
Fix PR_NUMBER var, use github event

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -116,7 +116,7 @@ jobs:
         EOF
         echo Deploying application
         skaffold config set --global local-cluster false
-        skaffold run --default-repo=gcr.io/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE
+        skaffold run --default-repo=gcr.io/$PROJECT_ID/$GITHUB_REF --tag=$PR_NUMBER --namespace=$NAMESPACE
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PROJECT_ID: ${{ secrets.PROJECT_ID }}

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -104,10 +104,8 @@ jobs:
     - name: Build + Deploy PR images to GKE
       timeout-minutes: 20
       run: |
-        PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
         NAMESPACE="pr${PR_NUMBER}"
         echo "::set-env name=NAMESPACE::$NAMESPACE"
-        echo "::set-env name=PR_NUMBER::$PR_NUMBER"
 
         gcloud container clusters get-credentials $PR_CLUSTER --zone $ZONE --project $PROJECT_ID
         cat <<EOF | kubectl apply -f -
@@ -120,6 +118,7 @@ jobs:
         skaffold config set --global local-cluster false
         skaffold run --default-repo=gcr.io/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE
       env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
         PR_CLUSTER: ${{ secrets.PR_CLUSTER_2 }}
         ZONE: ${{ secrets.PR_CLUSTER_2_ZONE }}
@@ -142,7 +141,6 @@ jobs:
       timeout-minutes: 5
       run: |
         set -x
-        PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
         NAMESPACE="pr${PR_NUMBER}"
         get_externalIP() {
           kubectl get service frontend --namespace $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
@@ -155,6 +153,7 @@ jobs:
         echo "::set-env name=EXTERNAL_IP::$EXTERNAL_IP"
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+        PR_NUMBER: ${{ github.event.pull_request.number }}
     - name: Comment EXTERNAL_IP
       timeout-minutes: 5
       env:


### PR DESCRIPTION
Now that CI-PR uses `pull_requests_target`, the `GITHUB_SHA` no longer refers to the PR number but rather the last commit on the base branch, meaning `master`. This is causing a bug where all the PRs are being staged in `prmaster`, instead of `pr#`, resulting in clobbering. 
 
Get the PR # directly instead. 