### PR TITLE
Add frontend whereami endpoint + UI info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target/
 .DS_Store
 *.iml
 .idea/
+settings.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.pylintEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.pylintEnabled": true
-}

--- a/src/frontend/frontend.py
+++ b/src/frontend/frontend.py
@@ -19,6 +19,7 @@ import datetime
 import json
 import logging
 import os
+import socket
 from decimal import Decimal
 
 import requests
@@ -69,7 +70,7 @@ def create_app():
         Returns the cluster name + zone name where this Pod is running.
 
         """
-        return cluster_name + " in " + cluster_zone, 200
+        return "Cluster: " + cluster_name + ", Pod: " + pod_name + ", Zone: " + pod_zone, 200
 
     @app.route("/")
     def root():
@@ -134,7 +135,8 @@ def create_app():
 
         return render_template('index.html',
                                cluster_name=cluster_name,
-                               cluster_zone=cluster_zone,
+                               pod_name=pod_name,
+                               pod_zone=pod_zone,
                                cymbal_logo=os.getenv('CYMBAL_LOGO', 'false'),
                                history=transaction_list,
                                balance=balance,
@@ -353,6 +355,9 @@ def create_app():
 
         return render_template('login.html',
                                cymbal_logo=os.getenv('CYMBAL_LOGO', 'false'),
+                               cluster_name=cluster_name,
+                               pod_name=pod_name,
+                               pod_zone=pod_zone,
                                message=request.args.get('msg', None),
                                default_user=os.getenv('DEFAULT_USERNAME', ''),
                                default_password=os.getenv('DEFAULT_PASSWORD', ''),
@@ -409,6 +414,9 @@ def create_app():
                                     _scheme=app.config['SCHEME']))
         return render_template('signup.html',
                                cymbal_logo=os.getenv('CYMBAL_LOGO', 'false'),
+                               cluster_name=cluster_name,
+                               pod_name=pod_name,
+                               pod_zone=pod_zone,
                                bank_name=os.getenv('BANK_NAME', 'Bank of Anthos'))
 
 
@@ -509,26 +517,31 @@ def create_app():
     app.config['SCHEME'] = os.environ.get('SCHEME', 'http')
 
     # where am I?
-    cluster_name="undefined"
-    cluster_zone="undefined"
     metadata_url = 'http://metadata.google.internal/computeMetadata/v1/'
     metadata_headers = {'Metadata-Flavor': 'Google'}
     # get GKE cluster name
+    cluster_name = "unknown"
     try:
         req = requests.get(metadata_url + 'instance/attributes/cluster-name',
-                            headers=metadata_headers)
+                           headers=metadata_headers)
         if req.ok:
             cluster_name = str(req.text)
     except (RequestException, HTTPError) as err:
         app.logger.warning("Unable to capture GKE cluster name.")
-    # get GCP zone
+
+    # get GKE pod name
+    pod_name = "unknown"
+    pod_name = socket.gethostname()
+
+    # get GKE node zone
+    pod_zone = "unknown"
     try:
         req = requests.get(metadata_url + 'instance/zone',
-                            headers=metadata_headers)
+                           headers=metadata_headers)
         if req.ok:
-            cluster_zone = str(req.text.split("/")[3])
+            pod_zone = str(req.text.split("/")[3])
     except (RequestException, HTTPError) as err:
-        app.logger.warning("Unable to capture GKE cluster zone.")
+        app.logger.warning("Unable to capture GKE node zone.")
 
     # register formater functions
     app.jinja_env.globals.update(format_currency=format_currency)

--- a/src/frontend/templates/index.html
+++ b/src/frontend/templates/index.html
@@ -437,7 +437,7 @@ limitations under the License.
             <div class="row mb-2" class="footer-google-inc">© 2020 Google Inc</div>
             <div class="row mb-3">
               <small class="footer-disclaimer">
-                Cluster: {{ cluster_name }}, Region: {{ cluster_zone }}
+                <b>Cluster: </b>{{ cluster_name }}, <b>Pod: </b>{{ pod_name }}<b>, Zone: </b>{{ pod_zone }}
               </small>
             </div>
             <div class="row mb-3">

--- a/src/frontend/templates/index.html
+++ b/src/frontend/templates/index.html
@@ -437,6 +437,11 @@ limitations under the License.
             <div class="row mb-2" class="footer-google-inc">© 2020 Google Inc</div>
             <div class="row mb-3">
               <small class="footer-disclaimer">
+                Cluster: {{ cluster_name }}, Region: {{ cluster_zone }}
+              </small>
+            </div>
+            <div class="row mb-3">
+              <small class="footer-disclaimer">
                 This website is hosted for demo purposes only. It is not an
                 actual bank. This is not an official Google project.
               </small>

--- a/src/frontend/templates/login.html
+++ b/src/frontend/templates/login.html
@@ -124,13 +124,17 @@ limitations under the License.
             <div class="row mb-2" class="footer-google-inc">© 2020 Google Inc</div>
             <div class="row mb-3">
               <small class="footer-disclaimer">
+                <b>Cluster: </b>{{ cluster_name }}, <b>Pod: </b>{{ pod_name }}<b>, Zone: </b>{{ pod_zone }}
+              </small>
+            </div>
+            <div class="row mb-3">
+              <small class="footer-disclaimer">
                 This website is hosted for demo purposes only. It is not an
                 actual bank. This is not an official Google project.
               </small>
             </div>
         </div>
       </footer>
-
       <!-- JavaScript Libs -->
       <!-- jQuery first, then Popper.js, then Bootstrap JS -->
       <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>

--- a/src/frontend/templates/signup.html
+++ b/src/frontend/templates/signup.html
@@ -344,6 +344,11 @@ limitations under the License.
             <div class="row mb-2" class="footer-google-inc">© 2020 Google Inc</div>
             <div class="row mb-3">
               <small class="footer-disclaimer">
+                <b>Cluster: </b>{{ cluster_name }}, <b>Pod: </b>{{ pod_name }}<b>, Zone: </b>{{ pod_zone }}
+              </small>
+            </div>
+            <div class="row mb-3">
+              <small class="footer-disclaimer">
                 This website is hosted for demo purposes only. It is not an
                 actual bank. This is not an official Google project.
               </small>


### PR DESCRIPTION
Fixes #377 

Adds a frontend endpoint + UI info for cluster name, pod name, and node zone. 

<img width="866" alt="Screen Shot 2021-01-14 at 1 27 37 PM" src="https://user-images.githubusercontent.com/3137106/104634270-65d85600-566e-11eb-870e-324e61065c76.png">


