### PR TITLE
Add liveness probe to the frontend container

### DIFF
--- a/dev-kubernetes-manifests/frontend.yaml
+++ b/dev-kubernetes-manifests/frontend.yaml
@@ -74,6 +74,13 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 30
         resources:
           requests:
             cpu: 100m

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -74,6 +74,13 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 30
         resources:
           requests:
             cpu: 100m

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -74,13 +74,6 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 10
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: 8080
-          initialDelaySeconds: 60
-          periodSeconds: 15
-          timeoutSeconds: 30
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Improvement for #447 

**Change summary:**
- Add liveness probe to the frontend container, such that any non-responsiveness in the API for more than 30 seconds should result in the container getting restarted.

**Remaining issues / concerns:**
- There still exist an underlying issues (potentially with `gunicorn`) surrounding the frontend API not being responsive that should be addressed (thus, let's leave #447 opened.)
- Open question: The timeouts I have chosen for the liveness probe are fairly arbitrary in choosing (though intentionally longer than the readiness probe, since we don't want any unnecessary reboots if for example there was just a higher load than usual on the frontend and that the API is just taking a couple seconds to reply)
- Thought: The liveness probe does the same check than the readiness probe. That doesn't cause in issues per-se, it is just a bit redundant. We could think of improving the readiness probe down the line to do some more dependency-based checks.

**Testing:**
I have tested this by deploying my branch onto a GKE cluster:
```
~ kubectl get pods | grep frontend
frontend-84cd68f957-rk9n8             1/1     Running   0          7m1s
```

```
~ kubectl describe pod/frontend-84cd68f957-rk9n8
    Liveness:   http-get http://:8080/ready delay=60s timeout=30s period=15s #success=1 #failure=3
    Readiness:  http-get http://:8080/ready delay=10s timeout=10s period=5s #success=1 #failure=3
```

And then `exec` into the frontend container to find the API sub-process and kill it (`ps` and `kill -9`), which resulted in a reboot a few seconds later:
```
~ kubectl get pods | grep frontend
frontend-84cd68f957-rk9n8             0/1     Running   1          19m
```
```
~ kubectl get pods | grep frontend
frontend-84cd68f957-rk9n8             1/1     Running   1          19m
```