### PR TITLE
Add gh actions label

### DIFF
--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -21,7 +21,7 @@ on:
       - release/*
 jobs:
   code-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, live]
     steps:
     - uses: actions/checkout@v2
     - name: License Check
@@ -95,7 +95,7 @@ jobs:
           popd
         done
   deployment-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, live]
     needs: code-tests
     strategy:
       matrix:

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -19,7 +19,7 @@ on:
       - master
 jobs:
   code-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, live]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -96,7 +96,7 @@ jobs:
           popd
         done
   deployment-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, live]
     needs: code-tests
     strategy:
       matrix:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -21,7 +21,7 @@ on:
     types: closed
 jobs:
   cleanup-namespace:
-    runs-on: self-hosted
+    runs-on: [self-hosted, live]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -20,7 +20,7 @@ on:
       - master
 jobs:
   push-deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, live]
     steps:
     - uses: actions/checkout@v2
     - name: Push latest images to GCR


### PR DESCRIPTION
Fixes # 
Issues with creating a new host for use by GitHub Actions pipeline. Without this change when a new host is being added to the GitHub Actions pipeline - _before it is fully setup and ready to take on jobs_ - incoming events may trigger a workflow on that un-ready host. 

To evade this, it is necessary to ensure incoming events are always scheduled on existing hosts and the new one must be used only when it is fully ready.

**_Change summary:_**
- Add a **live** label to all the Github actions workflows
- Also add the same label to the existing hosts under `Settings -> Actions`
