### PR TITLE
Change imgs & links to relative paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you’re using this app, please ★Star the repository to show your interest!
 
 | Sign in                                                                                                        | Home                                                                                                    |
 | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| [![Login](/docs/login.png)](/docs/login.png) | [![User Transactions](/docs/transactions.png)](/docs/transactions.png) |
+| [![Login](./docs/login.png)](./docs/login.png) | [![User Transactions](./docs/transactions.png)](./docs/transactions.png) |
 
 
 ## Service Architecture
@@ -117,20 +117,20 @@ EXTERNAL-IP
 
 ## Other Deployment Options
 
-- **Workload Identity**: [See these instructions.](docs/workload-identity.md)
-- **Cloud SQL**: [See these instructions](extras/cloudsql) to replace the in-cluster databases with hosted Google Cloud SQL.
-- **Multicluster with Cloud SQL**: [See these instructions](extras/cloudsql-multicluster) to replicate the app across two regions using GKE, Multi-cluster Ingress, and Google Cloud SQL.
+- **Workload Identity**: [See these instructions.](./docs/workload-identity.md)
+- **Cloud SQL**: [See these instructions](./extras/cloudsql) to replace the in-cluster databases with hosted Google Cloud SQL.
+- **Multicluster with Cloud SQL**: [See these instructions](./extras/cloudsql-multicluster) to replicate the app across two regions using GKE, Multi-cluster Ingress, and Google Cloud SQL.
 - **Istio**: Apply `istio-manifests/` to your cluster to access the frontend through the IngressGateway.
-- **Anthos Service Mesh**: ASM requires Workload Identity to be enabled in your GKE cluster. [See the workload identity instructions](docs/workload-identity.md) to configure and deploy the app. Then, apply `istio-manifests/` to your cluster to configure frontend ingress.
-- **Java Monolith (VM)**: We provide a version of this app where the three Java microservices are coupled together into one monolithic service, which you can deploy inside a VM (eg. Google Compute Engine). See the [ledgermonolith](src/ledgermonolith) directory.
+- **Anthos Service Mesh**: ASM requires Workload Identity to be enabled in your GKE cluster. [See the workload identity instructions](./docs/workload-identity.md) to configure and deploy the app. Then, apply `istio-manifests/` to your cluster to configure frontend ingress.
+- **Java Monolith (VM)**: We provide a version of this app where the three Java microservices are coupled together into one monolithic service, which you can deploy inside a VM (eg. Google Compute Engine). See the [ledgermonolith](./src/ledgermonolith) directory.
 
 ## Troubleshooting
 
-See the [Troubleshooting guide](docs/troubleshooting.md) for resolving common problems.
+See the [Troubleshooting guide](./docs/troubleshooting.md) for resolving common problems.
 
 ## Development
 
-See the [Development guide](docs/development.md) to learn how to run and develop this app locally.
+See the [Development guide](./docs/development.md) to learn how to run and develop this app locally.
 
 ## Talks/Demos using Bank of Anthos
 


### PR DESCRIPTION
Change summary:
- [issue]: images & links with absolute paths break when BoA is nested in another repo, i.e. [Custom Samples](https://github.com/GoogleCloudPlatform/cloud-code-custom-samples-example)
- [fix]: changed paths in main README to relative paths