### PR TITLE
Clarify Java & mvn requirements

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -14,8 +14,8 @@ You can use MacOS or Linux as your dev environment - all these languages and too
 1. [Docker Desktop](https://www.docker.com/products/docker-desktop) 
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (can be installed separately or via [gcloud](https://cloud.google.com/sdk/install)) 
 1. [skaffold](https://skaffold.dev/docs/install/) 
-1. [JDK 14](https://www.oracle.com/java/technologies/javase-jdk14-downloads.html)
-1. [Maven 3.6](https://maven.apache.org/install.html)
+1. [JDK **14**](https://www.oracle.com/java/technologies/javase/jdk14-archive-downloads.html) (newer versions might cause issues)
+1. [Maven **3.6**](https://downloads.apache.org/maven/maven-3/) (newer versions might cause issues)
 1. [Python3](https://www.python.org/downloads/)  
 1. [piptools](https://pypi.org/project/pip-tools/)
 


### PR DESCRIPTION
~Fixes~ Addresses #503.

Change summary:
- The version of JDK and maven specified in the `docs/development.md` file is now **bolded**.
- The URLs to the JDK and maven installations lead to the specific version (not the general "Download" page). Let me know if this is a bad idea.
- I've added a note, "newer versions might cause issues", for both JDK and maven.

Remaining issues / concerns:
- This obviously doesn't "fix" #503. Ideally, Bank of Anthos would be compatible with the latest stable versions of JDK and maven. 
