### PR TITLE
Switch Java services from Jib to Docker

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,43 +11,51 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: skaffold/v2alpha4
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/bank-of-anthos/frontend
+  - image: frontend
     context: src/frontend
-  - image: gcr.io/bank-of-anthos/ledgerwriter
-    jib:
-      project: src/ledgerwriter
-  - image: gcr.io/bank-of-anthos/balancereader
-    jib:
-      project: src/balancereader
-  - image: gcr.io/bank-of-anthos/transactionhistory
-    jib:
-      project: src/transactionhistory
-  - image: gcr.io/bank-of-anthos/contacts
+  - image: ledgerwriter
+    context: src/ledgerwriter
+  - image: balancereader
+    context: src/balancereader
+  - image: transactionhistory
+    context: src/transactionhistory
+  - image: contacts
     context: src/contacts
-  - image: gcr.io/bank-of-anthos/userservice
+  - image: userservice
     context: src/userservice
-  - image: gcr.io/bank-of-anthos/loadgenerator
+  - image: loadgenerator
     context: src/loadgenerator
-  - image: gcr.io/bank-of-anthos/accounts-db
-    context: src/accounts-db
-  - image: gcr.io/bank-of-anthos/ledger-db
-    context: src/ledger-db
   tagPolicy:
     gitCommit: {}
-  local:
-    concurrency: 0
+  local: 
+    concurrency: 4 
 deploy:
-  statusCheckDeadlineSeconds: 300
-  kubectl:
-    manifests:
-    - ./dev-kubernetes-manifests/**.yaml
-    # deploy a pre-build secret
-    # in practice, this should not be checked in to source control
-    - ./extras/jwt/jwt-secret.yaml
+  statusCheckDeadlineSeconds: 600
+  kustomize: {}
+portForward:
+- resourceType: deployment
+  resourceName: frontend
+  namespace: frontend
+  port: 8080
+  address: 127.0.0.1
+  localPort: 80
 profiles:
-  - name: local-code
+  - name: dev
+    deploy: 
+      kustomize: 
+        paths:
+          - "cymbalbank-app-config/overlays/dev"
+  - name: staging
+    deploy: 
+      kustomize: 
+        paths:
+          - "cymbalbank-app-config/overlays/dev"
+  - name: prod
+    deploy: 
+      kustomize: 
+        paths:
+          - "cymbalbank-app-config/overlays/prod"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -16,20 +16,25 @@ apiVersion: skaffold/v2alpha4
 kind: Config
 build:
   artifacts:
-  - image: frontend
+  artifacts:
+  - image: gcr.io/bank-of-anthos/frontend
     context: src/frontend
-  - image: ledgerwriter
+  - image: gcr.io/bank-of-anthos/ledgerwriter
     context: src/ledgerwriter
-  - image: balancereader
+  - image: gcr.io/bank-of-anthos/balancereader
     context: src/balancereader
-  - image: transactionhistory
+  - image: gcr.io/bank-of-anthos/transactionhistory
     context: src/transactionhistory
-  - image: contacts
+  - image: gcr.io/bank-of-anthos/contacts
     context: src/contacts
-  - image: userservice
+  - image: gcr.io/bank-of-anthos/userservice
     context: src/userservice
-  - image: loadgenerator
+  - image: gcr.io/bank-of-anthos/loadgenerator
     context: src/loadgenerator
+  - image: gcr.io/bank-of-anthos/accounts-db
+    context: src/accounts-db
+  - image: gcr.io/bank-of-anthos/ledger-db
+    context: src/ledger-db
   tagPolicy:
     gitCommit: {}
   local:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: skaffold/v2alpha4
 kind: Config
 build:
@@ -31,31 +32,15 @@ build:
     context: src/loadgenerator
   tagPolicy:
     gitCommit: {}
-  local: 
-    concurrency: 4 
+  local:
+    concurrency: 0
 deploy:
-  statusCheckDeadlineSeconds: 600
-  kustomize: {}
-portForward:
-- resourceType: deployment
-  resourceName: frontend
-  namespace: frontend
-  port: 8080
-  address: 127.0.0.1
-  localPort: 80
+  statusCheckDeadlineSeconds: 300
+  kubectl:
+    manifests:
+    - ./dev-kubernetes-manifests/**.yaml
+    # deploy a pre-build secret
+    # in practice, this should not be checked in to source control
+    - ./extras/jwt/jwt-secret.yaml
 profiles:
-  - name: dev
-    deploy: 
-      kustomize: 
-        paths:
-          - "cymbalbank-app-config/overlays/dev"
-  - name: staging
-    deploy: 
-      kustomize: 
-        paths:
-          - "cymbalbank-app-config/overlays/dev"
-  - name: prod
-    deploy: 
-      kustomize: 
-        paths:
-          - "cymbalbank-app-config/overlays/prod"
+  - name: local-code

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -16,7 +16,6 @@ apiVersion: skaffold/v2alpha4
 kind: Config
 build:
   artifacts:
-  artifacts:
   - image: gcr.io/bank-of-anthos/frontend
     context: src/frontend
   - image: gcr.io/bank-of-anthos/ledgerwriter

--- a/src/balancereader/Dockerfile
+++ b/src/balancereader/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM maven:3.6.3-jdk-14 AS build
+COPY src /usr/src/app/src  
+COPY pom.xml /usr/src/app  
+RUN mvn -f /usr/src/app/pom.xml clean package
+
+FROM gcr.io/distroless/java  
+COPY --from=build /usr/src/app/target/balancereader-1.0.jar /usr/app/balancereader-1.0.jar  
+EXPOSE 8080  
+ENTRYPOINT ["java","-jar","/usr/app/balancereader-1.0.jar"]  

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -148,11 +148,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>2.1.0</version>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>

--- a/src/ledgerwriter/Dockerfile
+++ b/src/ledgerwriter/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM maven:3.6.3-jdk-14 AS build
+COPY src /usr/src/app/src  
+COPY pom.xml /usr/src/app  
+RUN mvn -f /usr/src/app/pom.xml clean package
+
+FROM gcr.io/distroless/java  
+COPY --from=build /usr/src/app/target/ledgerwriter-1.0.jar /usr/app/ledgerwriter-1.0.jar  
+EXPOSE 8080  
+ENTRYPOINT ["java","-jar","/usr/app/ledgerwriter-1.0.jar"]  

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -147,11 +147,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>2.1.0</version>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>

--- a/src/transactionhistory/Dockerfile
+++ b/src/transactionhistory/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM maven:3.6.3-jdk-14 AS build
+COPY src /usr/src/app/src  
+COPY pom.xml /usr/src/app  
+RUN mvn -f /usr/src/app/pom.xml clean package
+
+FROM gcr.io/distroless/java  
+COPY --from=build /usr/src/app/target/transactionhistory-1.0.jar /usr/app/transactionhistory-1.0.jar  
+EXPOSE 8080  
+ENTRYPOINT ["java","-jar","/usr/app/transactionhistory-1.0.jar"]  

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -148,11 +148,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>2.1.0</version>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
Addresses an ongoing Jib dependency bug that occurs whenever we run `skaffold build` or `skaffold run` inside Cloud Build - 

```
failed to build: getting hash for artifact "transactionhistory": getting dependencies for "transactionhistory": could not fetch dependencies for workspace .: initial Jib dependency refresh failed: failed to get Jib dependencies: running [/workspace/mvnw jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=1.4.0 --projects src/transactionhistory --also-make jib:_skaffold-files-v2 --quiet --batch-mode]
```

**Changelog**:
- Add Dockerfiles for each of the 3 Java microservices services. Uses the Google Java Distroless image / multistage build
- Update skaffold file to remove Jib dependency 
- Remove Jib from pom.xml from the three Java services 

**note** - this change does increase the final image size somewhat, from (for instance) 117MB (Balancereader, Jib) to 137 MB (Balancereader, Docker.) 

**note** - the ledger monolith is left intact. (still uses jib.) 