### PR TITLE
Split single skaffold config into modularized skaffold configs

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -12,12 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2alpha4
+apiVersion: skaffold/v2beta18
 kind: Config
+metadata:
+  name: setup # module defining setup steps
+deploy:
+  kubectl:
+    manifests: 
+    - extras/jwt/jwt-secret.yaml
+    - dev-kubernetes-manifests/config.yaml
+
+---
+
+apiVersion: skaffold/v2beta15
+kind: Config
+metadata:
+  name: db # module defining database deployments
+requires:
+  - configs: [setup]
 build:
   artifacts:
-  - image: gcr.io/bank-of-anthos/frontend
-    context: src/frontend
+  - image: gcr.io/bank-of-anthos/accounts-db
+    context: src/accounts-db
+  - image: gcr.io/bank-of-anthos/ledger-db
+    context: src/ledger-db
+deploy:
+  kubectl:
+    manifests:
+    - dev-kubernetes-manifests/accounts-db.yaml
+    - dev-kubernetes-manifests/ledger-db.yaml
+
+---
+
+apiVersion: skaffold/v2beta18
+kind: Config
+metadata:
+  name: backend # module defining backend services
+requires:
+  - configs: [db]
+build:
+  artifacts:
   - image: gcr.io/bank-of-anthos/ledgerwriter
     jib:
       project: src/ledgerwriter
@@ -31,23 +65,45 @@ build:
     context: src/contacts
   - image: gcr.io/bank-of-anthos/userservice
     context: src/userservice
-  - image: gcr.io/bank-of-anthos/loadgenerator
-    context: src/loadgenerator
-  - image: gcr.io/bank-of-anthos/accounts-db
-    context: src/accounts-db
-  - image: gcr.io/bank-of-anthos/ledger-db
-    context: src/ledger-db
-  tagPolicy:
-    gitCommit: {}
-  local:
-    concurrency: 0
 deploy:
-  statusCheckDeadlineSeconds: 300
   kubectl:
     manifests:
-    - ./dev-kubernetes-manifests/**.yaml
-    # deploy a pre-build secret
-    # in practice, this should not be checked in to source control
-    - ./extras/jwt/jwt-secret.yaml
-profiles:
-  - name: local-code
+    - dev-kubernetes-manifests/balance-reader.yaml
+    - dev-kubernetes-manifests/contacts.yaml
+    - dev-kubernetes-manifests/ledger-writer.yaml
+    - dev-kubernetes-manifests/transaction-history.yaml
+    - dev-kubernetes-manifests/userservice.yaml
+
+---
+
+apiVersion: skaffold/v2beta18
+kind: Config
+metadata:
+  name: frontend # module defining frontend service
+requires:
+  - configs: [backend]
+build:
+  artifacts:
+  - image: gcr.io/bank-of-anthos/frontend
+    context: src/frontend
+deploy:
+  kubectl:
+    manifests:
+    - dev-kubernetes-manifests/frontend.yaml
+
+---
+
+apiVersion: skaffold/v2beta18
+kind: Config
+metadata:
+  name: loadgenerator # module defining a load generator service
+requires:
+  - configs: [backend]
+build:
+  artifacts:
+  - image: gcr.io/bank-of-anthos/loadgenerator
+    context: src/loadgenerator
+deploy:
+  kubectl:
+    manifests:
+    - dev-kubernetes-manifests/loadgenerator.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -24,7 +24,7 @@ deploy:
 
 ---
 
-apiVersion: skaffold/v2beta15
+apiVersion: skaffold/v2beta18
 kind: Config
 metadata:
   name: db # module defining database deployments


### PR DESCRIPTION
This PR is a rework of #490 incorporating some of the review feedback.

## Motivation:
Update this project's use of `skaffold` to incorporate two new features:
- [multiple configuration support](https://skaffold.dev/docs/design/config/#multiple-configuration-support) that allows defining more than one `build-sync-deploy` pipeline in the same `skaffold.yaml` document.
- [configuration dependencies](https://skaffold.dev/docs/design/config/#configuration-dependencies) that allows defining dependencies between different skaffold configurations.

These two features together allow hierarchical build and deploy operations for multi-microservice and multi-repository applications. It also allows running individual _modules_ instead of the previous all-or-nothing approach.

Two examples of this being used are forks of this repo:
- https://github.com/gsquared94/bank-of-anthos-demo
- https://github.com/gsquared94/skaffold-remote-configs-demo
---
In this PR, we separate out 5 modules:
- a `setup` module to deploy the JWT secret and config maps
- a `db` module that deploys the two database services `accounts-db` and `ledger-db`
- a `backend` module that deploys all the backend services `balance-reader`,`contacts`,`ledger-writer`,`transaction-history` and `userservice`.
- a `frontend` module that deploys the `frontend` service
- a `loadgenerator` module that deploys the `loadgenerator` service

The dependency between the modules is setup using the `requires` keyword in each module definition.

---
With this change, we can still run the following with no problems:
```
skaffold dev --default-repo=gcr.io/$PROJECT_ID/bank-of-anthos
```

But now we can also run a subset of the application using the `--module` flag.
Run only the database services:
```
skaffold dev --default-repo=gcr.io/$PROJECT_ID/bank-of-anthos --module db
```
Run the app without a frontend:

```
skaffold dev --default-repo=gcr.io/$PROJECT_ID/bank-of-anthos --module backend
```

Scoping the run by modules still honors the dependency graph setup using the `requires` keyword across modules, so invoking `backend` module will also invoke `db` and `setup` modules.
 
## Change summary:
- Update skaffold config version to latest.
- Split into multiple skaffold modules.

Remaining issues / concerns:
- Cloudshell tutorial should elaborate on being able to trigger individual modules using the `--module` flag once supported in CloudCode IDEs. 
