### PR TITLE
Recommend skaffold version in development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,7 +13,7 @@ You can use MacOS or Linux as your dev environment - all these languages and too
 
 1. [Docker Desktop](https://www.docker.com/products/docker-desktop) 
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (can be installed separately or via [gcloud](https://cloud.google.com/sdk/install)) 
-1. [skaffold](https://skaffold.dev/docs/install/) 
+1. [skaffold **1.27+**](https://skaffold.dev/docs/install/) (latest version recommended)
 1. [JDK **14**](https://www.oracle.com/java/technologies/javase/jdk14-archive-downloads.html) (newer versions might cause issues)
 1. [Maven **3.6**](https://downloads.apache.org/maven/maven-3/) (newer versions might cause issues)
 1. [Python3](https://www.python.org/downloads/)  


### PR DESCRIPTION
**Background**
* In https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/514, we update(d) the `skaffold.yaml` file that configures the development on Bank of Anthos.
* The new configuration requires `skaffold` version 1.27 or higher according to [my testing](https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/514#pullrequestreview-713779181).

**Change summary:**
- Recommend `skaffold` version 1.27 or higher in the `development.md`.


**Remaining issues / concerns:**
- N/A
