### PR TITLE
Structure logs to display correctly in Cloud Operations

### DIFF
--- a/src/balancereader/src/main/resources/log4j2.xml
+++ b/src/balancereader/src/main/resources/log4j2.xml
@@ -19,7 +19,7 @@
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout
-                pattern="%d{yyyy-MM-dd HH:mm:ss} | [%level] | %M | %msg%n" />
+                pattern='{"timestamp": "%d{yyyy-MM-dd HH:mm:ss}", "message": "%M | %msg", "severity": "%level"}%n' />
         </Console>
     </Appenders>
     <Loggers>

--- a/src/contacts/logging.conf
+++ b/src/contacts/logging.conf
@@ -28,6 +28,6 @@ formatter=generic
 args=(sys.stdout, )
 
 [formatter_generic]
-format=%(asctime)s | [%(levelname)s] | %(funcName)s | %(message)s
+format={"timestamp": "%(asctime)s", "message": "%(funcName)s | %(message)s", "severity": "%(levelname)s"}
 datefmt=%Y-%m-%d %H:%M:%S
 class=logging.Formatter

--- a/src/frontend/logging.conf
+++ b/src/frontend/logging.conf
@@ -28,6 +28,6 @@ formatter=generic
 args=(sys.stdout, )
 
 [formatter_generic]
-format=%(asctime)s | [%(levelname)s] | %(funcName)s | %(message)s
+format={"timestamp": "%(asctime)s", "message": "%(funcName)s | %(message)s", "severity": "%(levelname)s"}
 datefmt=%Y-%m-%d %H:%M:%S
 class=logging.Formatter

--- a/src/ledgerwriter/src/main/resources/log4j2.xml
+++ b/src/ledgerwriter/src/main/resources/log4j2.xml
@@ -19,7 +19,7 @@
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout
-                pattern="%d{yyyy-MM-dd HH:mm:ss} | [%level] | %M | %msg%n" />
+                pattern='{"timestamp": "%d{yyyy-MM-dd HH:mm:ss}", "message": "%M | %msg", "severity": "%level"}%n' />
         </Console>
     </Appenders>
     <Loggers>

--- a/src/transactionhistory/src/main/resources/log4j2.xml
+++ b/src/transactionhistory/src/main/resources/log4j2.xml
@@ -19,7 +19,7 @@
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout
-              pattern="%d{yyyy-MM-dd HH:mm:ss} | [%level] | %M | %msg%n" />
+              pattern='{"timestamp": "%d{yyyy-MM-dd HH:mm:ss}", "message": "%M | %msg", "severity": "%level"}%n' />
         </Console>
     </Appenders>
     <Loggers>

--- a/src/userservice/logging.conf
+++ b/src/userservice/logging.conf
@@ -28,6 +28,6 @@ formatter=generic
 args=(sys.stdout, )
 
 [formatter_generic]
-format=%(asctime)s | [%(levelname)s] | %(funcName)s | %(message)s
+format={"timestamp": "%(asctime)s", "message": "%(funcName)s | %(message)s", "severity": "%(levelname)s"}
 datefmt=%Y-%m-%d %H:%M:%S
 class=logging.Formatter


### PR DESCRIPTION
Fixes #498

This PR makes sure that logs are displayed with the intended severity level in Cloud Operations (i.e. avoiding false classification of logs like showing all logs as error or all logs as info regardless of severity).

## Overview

There are multiple ways to direct logs to Cloud Operations. For example, there are Google APIs and libraries that can be used specifically for this purpose. Alternatively, Operations is also able to read logs from known streams such as `stdout` and `stderr`. If read from those streams, it will classify all logs as `INFO` or all logs as `ERROR`, respectably. To avoid this, we can use structured logging (typically in JSON format) with specific keywords for fields that Operations recognizes.

These fields are documented here: https://cloud.google.com/logging/docs/structured-logging

Among others are `message` which is the summary that gets displayed in the query results, as well as `severity` which sets the level of the log within Logs Explorer.

## Open questions

**Postgres services:** By default, Postgres services logs are all directed to `stderr` (https://www.postgresql.org/docs/12/runtime-config-logging.html) which may create false negative (i.e. info-level logs displayed as errors). An alternative would be to redirect all logs to `stdout` or similar which would have the opposite problem (i.e. error-level log displayed as info). CSV is also supported, but doesn't seem to play well with Cloud Operations. I prefer sticking to `stderr` (the current default) than moving to `stdout`. There may be a way to do structured JSON logs but it doesn't seem to be natively supported by Postgres. Thoughts?

**Function names:** I have kept the function names in the summary of the logs for easily parsing it in the list of summaries, but perhaps it makes more sense to be hidden / tucked away into its own JSON field. Should we leave it in the summary or hide it in the JSON payload?

## Examples

### Python services

#### INFO

![image](https://user-images.githubusercontent.com/3271352/127434599-8ed62a24-f2c2-4486-ac78-f972b84b1487.png)

#### ERROR

![image](https://user-images.githubusercontent.com/3271352/127434623-7c0c4c4b-b382-4b92-925d-d4a1f6616399.png)

### Java services

#### INFO

![image](https://user-images.githubusercontent.com/3271352/127434445-c6a4fe51-2c70-4cc6-9c6b-d6828fb37f1c.png)

#### ERROR

![image](https://user-images.githubusercontent.com/3271352/127434510-453a8d4c-9541-4aa8-b9e5-86176125b013.png)
