### PR TITLE
Update ledgermonolith service to simple

### DIFF
--- a/src/ledgermonolith/init/install-script.sh
+++ b/src/ledgermonolith/init/install-script.sh
@@ -130,7 +130,7 @@ chmod +x ${MONOLITH_DIR}/ledgermonolith-service.sh
 
 cat <<EOF >/etc/systemd/system/${MONOLITH_SERVICE}
 [Service]
-Type=oneshot
+Type=simple
 RemainAfterExit=yes
 ExecStart=${MONOLITH_DIR}/ledgermonolith-service.sh
 
@@ -143,4 +143,3 @@ systemctl start ${MONOLITH_SERVICE}
 
 echo "Install Complete"
 exit
-


### PR DESCRIPTION
Fixes #524 

Change summary:
- Update the `ledgermonolith` systemd service to be of type `simple` instead of `oneshot`

Tested and the VM still loads correctly (see transactions showing up):
![image](https://user-images.githubusercontent.com/3271352/131421168-707df7f0-57f4-4577-933b-bba44bff764d.png)
