### PR TITLE
Added PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Describe the bug 
+<!-- A clear and concise description of what the bug is. -->
+
+### To Reproduce 
+<!-- Steps to reproduce the behavior: -->
+<!-- 1. Built image '...' -->
+<!-- 2. Ran command '....' -->
+<!-- 3. See error -->
+
+### Logs  
+<!-- Add logs to help explain your problem -->
+
+### Screenshots 
+<!-- If applicable, add screenshots to help explain your problem -->
+
+### Environment 
+<!--  - OS: [e.g. MacOS Big Sur v11.6] -->
+<!--  - Kubernetes distribution, version: [e.g. minikube, GKE (Standard or Autopilot), EKS, AWS ... ] -->
+<!--  - Any relevant tool version: [e.g. Docker v20.10.8] -->
+
+### Additional context 
+<!-- Add any other context about the problem here -->
+
+### Exposure 
+<!-- Is the bug intermittent, persistent? Is it widespread, local? -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,6 +7,10 @@ assignees: ''
 
 ---
 
+Please check the [open issues](https://github.com/GoogleCloudPlatform/bank-of-anthos/issues) for this repository to verify that the same `issue/bug` has not been already reported. 
+
+If you see the bug being already reported, please upvote and comment on the existing issue instead of opening a new one. If you notice a `bug/issue` which is not the same as yours but is related, create a new one and link to the existing `bug/issue`.
+
 ### Describe the bug 
 <!-- A clear and concise description of what the bug is. -->
 
@@ -24,7 +28,7 @@ assignees: ''
 
 ### Environment 
 <!--  - OS: [e.g. MacOS Big Sur v11.6] -->
-<!--  - Kubernetes distribution, version: [e.g. minikube, GKE (Standard or Autopilot), EKS, AWS ... ] -->
+<!--  - Kubernetes distribution, version: [e.g. minikube, GKE (Standard or Autopilot), EKS, AKS ... ] -->
 <!--  - Any relevant tool version: [e.g. Docker v20.10.8] -->
 
 ### Additional context 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Describe request or inquiry 
+<!-- Add any other context about the problem or helpful links here! -->
+
+### What purpose/environment will this feature serve? 
+<!-- Add reasoning -->

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,10 @@
+---
+name: Other
+about: Have a question or need clarification?
+title: ''
+labels: ''
+assignees: ''
+
+---
+### Write down your inquiry 
+<!-- Write your question/inquiry here and any addition context -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,16 @@
-Fixes # .
+### Background 
+<!-- What was happening before this PR, and the problem(s) it solves -->
 
-Change summary:
-- 
+### Fixes 
+<!-- Link the issue(s) this PR fixes-->
+### Change Summary
+<!-- Short summary of the changes submitted -->
 
+### Additional Notes
+<!-- Any remaining concerns -->
 
-Remaining issues / concerns:
+### Testing Procedure
+<!-- If applicable, write how to test for reviewers-->
+
+### Related PRs or Issues 
+<!-- Dependent PRs, or any relevant linked issues -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
+### Fixes #<ISSUE_NUMBER>
+
 ### Background 
 <!-- What was happening before this PR, and the problem(s) it solves -->
 
-### Fixes 
-<!-- Link the issue(s) this PR fixes-->
 ### Change Summary
 <!-- Short summary of the changes submitted -->
 


### PR DESCRIPTION
Fixes # . N/A

Change summary:
- 
Adding Issue and PR templates similar to the microservice-demo (PR [here](https://github.com/GoogleCloudPlatform/microservices-demo/pull/627)) to improve context and consistency for new issues and pull requests.  Exact same files as in the microservice-demo repo.

Remaining issues / concerns:
N/A!
