### PR TITLE
cleanup: fix the background on the warning label

### DIFF
--- a/src/frontend/templates/index.html
+++ b/src/frontend/templates/index.html
@@ -291,7 +291,7 @@ limitations under the License.
                         </select>
                         <div id="otherDepositInputs" class="hidden">
                           <div id="alertBanner" class="alert alert-danger mt-3 mb-3" role="alert">
-                            <span class="alert-icon mr-2 material-icons">error</span><strong>Warning</strong>: This website is a simulation. Please don't include real personal information.
+                            <span class="error-icon mr-2 material-icons">error</span><strong>Warning</strong>: This website is a simulation. Please don't include real personal information.
                           </div>
                           <div class="input-group mb-3">
                             <div class="input-group-prepend">

--- a/src/frontend/templates/login.html
+++ b/src/frontend/templates/login.html
@@ -62,7 +62,7 @@ limitations under the License.
           {% if message != None and message != 'Login Failed' %}
           <div class="col-md-8 offset-md-2">
             <div class="alert alert-info alert-dismissible fade show" role="alert">
-              <span class="alert-icon mr-2 material-icons">error</span>{{ message }}
+              <span class="error-icon mr-2 material-icons">error</span>{{ message }}
               <button type="button" class="close btn-primary" data-dismiss="alert" aria-label="Close">
                 <span aria-hidden="true">×</span>
               </button>
@@ -81,7 +81,7 @@ limitations under the License.
                   <div class="row align-items-center mt-2">
                     <div class="col-10 offset-1 mb-4">
                       <div id="alertBanner" class="alert alert-danger mb-4" role="alert">
-                        <span class="alert-icon mr-2 material-icons">error</span>Login failed.
+                        <span class="error-icon mr-2 material-icons">error</span>Login failed.
                       </div>
                       <form id="login-form" class="needs-validation" novalidate="" method="POST" action="/login">
                         <label class="text-uppercase text-muted secondary-text" for="username">Username</label>


### PR DESCRIPTION
### Fixes #418

### Background 
- Update CSS to change the color of the warning circle

### Change Summary
- Minor css change

### Additional Notes
- NA

### Testing Procedure
- You can either host your own cluster or check in the CI cluster
- Create port forward to the frontend: `kubectl port-forward <POD_ID> -n <NAMESPACE> 8080:8080`
- Access the Pod via `localhost:8080`
- View the error label color in the following places
   - Adding a new credit card
   - Login fail attempt
   - Create new user with mismatching password  

### Related PRs or Issues 
- NA

### How you should see now:

![image](https://user-images.githubusercontent.com/7249208/145654269-ca710eca-3310-43c0-83e7-82ecdceb624e.png)
