### PR TITLE
Move canonical ledgermonolith artifact to bank-of-anthos-ci

### DIFF
--- a/src/ledgermonolith/README.md
+++ b/src/ledgermonolith/README.md
@@ -88,7 +88,7 @@ on a Google Compute Engine VM and all other microservices running on Kubernetes.
 
 Deploy the canonical version of the monolith to a Google Compute Engine VM.
 Use canonical build artifacts hosted on Google Cloud Storage at
-`gs://bank-of-anthos/monolith`.
+`gs://bank-of-anthos-ci/monolith`.
 
 ```
 # In the root directory of the project repo

--- a/src/ledgermonolith/scripts/deploy-monolith.sh
+++ b/src/ledgermonolith/scripts/deploy-monolith.sh
@@ -32,7 +32,7 @@ fi
 # Google Cloud Storage bucket to pull build artifacts from
 if [[ -z ${GCS_BUCKET} ]]; then
   # If no bucket specified, default to canonical build artifacts
-  GCS_BUCKET=bank-of-anthos
+  GCS_BUCKET=bank-of-anthos-ci
   echo "GCS_BUCKET not specified, defaulting to canonical pre-built artifacts..."
 fi
 echo "GCS_BUCKET: ${GCS_BUCKET}"


### PR DESCRIPTION
This RP moves the canonical `ledgermonolith` artifacts to the new GCP project and GS bucket, `bank-of-anthos-ci`.

```
~ make monolith-deploy                                                                                                   
# deploy the ledgermonolith service to a GCE VM
src/ledgermonolith/scripts/deploy-monolith.sh
PROJECT_ID: <redacted>
ZONE: us-east1-b
GCS_BUCKET: bank-of-anthos-ci
Cleaning up VM if it already exists...
Creating GCE instance...
Created [https://www.googleapis.com/compute/v1/projects/<redacted>/zones/us-east1-b/instances/ledgermonolith-service].
NAME: ledgermonolith-service
ZONE: us-east1-b
MACHINE_TYPE: n1-standard-1
PREEMPTIBLE:
INTERNAL_IP: <redacted>
EXTERNAL_IP: <redacted>
STATUS: RUNNING
```