### PR TITLE
Change the Skaffold target images to use bank-of-anthos-ci

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,8 +66,8 @@ Events:
   ----     ------       ----               ----                                             -------
   Normal   Scheduled    73s                default-scheduler                                Successfully assigned default/balancereader-fb6784fc-9fw2k to gke-toggles-default-pool-28882412-xljt
   Warning  FailedMount  72s (x2 over 72s)  kubelet, gke-toggles-default-pool-28882412-xljt  MountVolume.SetUp failed for volume "publickey" : secret "jwt-key" not found
-  Normal   Pulling      70s                kubelet, gke-toggles-default-pool-28882412-xljt  Pulling image "gcr.io/my-cool-project/bank-of-anthos/gcr.io/bank-of-anthos/balancereader:v0.2.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
-  Normal   Pulled       69s                kubelet, gke-toggles-default-pool-28882412-xljt  Successfully pulled image "gcr.io/my-cool-projectt/bank-of-anthos/gcr.io/bank-of-anthos/balancereader:v0.2.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
+  Normal   Pulling      70s                kubelet, gke-toggles-default-pool-28882412-xljt  Pulling image "gcr.io/my-cool-project/bank-of-anthos/gcr.io/bank-of-anthos/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
+  Normal   Pulled       69s                kubelet, gke-toggles-default-pool-28882412-xljt  Successfully pulled image "gcr.io/my-cool-projectt/bank-of-anthos/gcr.io/bank-of-anthos/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
   Normal   Created      69s                kubelet, gke-toggles-default-pool-28882412-xljt  Created container balancereader
   Normal   Started      69s                kubelet, gke-toggles-default-pool-28882412-xljt  Started container balancereader
   Warning  Unhealthy    4s (x2 over 9s)    kubelet, gke-toggles-default-pool-28882412-xljt  Readiness probe failed: Get http://10.0.1.141:8080/ready: dial tcp 10.0.1.141:8080: connect: connection refused

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -32,9 +32,9 @@ requires:
   - configs: [setup]
 build:
   artifacts:
-  - image: gcr.io/bank-of-anthos/accounts-db
+  - image: gcr.io/bank-of-anthos-ci/accounts-db
     context: src/accounts-db
-  - image: gcr.io/bank-of-anthos/ledger-db
+  - image: gcr.io/bank-of-anthos-ci/ledger-db
     context: src/ledger-db
 deploy:
   kubectl:
@@ -52,18 +52,18 @@ requires:
   - configs: [db]
 build:
   artifacts:
-  - image: gcr.io/bank-of-anthos/ledgerwriter
+  - image: gcr.io/bank-of-anthos-ci/ledgerwriter
     jib:
       project: src/ledgerwriter
-  - image: gcr.io/bank-of-anthos/balancereader
+  - image: gcr.io/bank-of-anthos-ci/balancereader
     jib:
       project: src/balancereader
-  - image: gcr.io/bank-of-anthos/transactionhistory
+  - image: gcr.io/bank-of-anthos-ci/transactionhistory
     jib:
       project: src/transactionhistory
-  - image: gcr.io/bank-of-anthos/contacts
+  - image: gcr.io/bank-of-anthos-ci/contacts
     context: src/contacts
-  - image: gcr.io/bank-of-anthos/userservice
+  - image: gcr.io/bank-of-anthos-ci/userservice
     context: src/userservice
 deploy:
   kubectl:
@@ -82,7 +82,7 @@ metadata:
   name: frontend # module defining frontend service
 build:
   artifacts:
-  - image: gcr.io/bank-of-anthos/frontend
+  - image: gcr.io/bank-of-anthos-ci/frontend
     context: src/frontend
 deploy:
   kubectl:
@@ -97,7 +97,7 @@ metadata:
   name: loadgenerator # module defining a load generator service
 build:
   artifacts:
-  - image: gcr.io/bank-of-anthos/loadgenerator
+  - image: gcr.io/bank-of-anthos-ci/loadgenerator
     context: src/loadgenerator
 deploy:
   kubectl:


### PR DESCRIPTION
I noticed that images from the latest commit were pushed to `gcr.io/bank-of-anthos-ci/gcr.io/bank-of-anthos/`. This PR fixes this to push directly to `gcr.io/bank-of-anthos-ci/`.