### PR TITLE
Change image refs to use bank-of-anthos-ci

### DIFF
--- a/dev-kubernetes-manifests/accounts-db.yaml
+++ b/dev-kubernetes-manifests/accounts-db.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: accounts-db
-        image: gcr.io/bank-of-anthos/accounts-db:latest
+        image: gcr.io/bank-of-anthos-ci/accounts-db:latest
         envFrom:
           - configMapRef:
               name: environment-config

--- a/dev-kubernetes-manifests/balance-reader.yaml
+++ b/dev-kubernetes-manifests/balance-reader.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos/balancereader:latest
+        image: gcr.io/bank-of-anthos-ci/balancereader:latest
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/dev-kubernetes-manifests/contacts.yaml
+++ b/dev-kubernetes-manifests/contacts.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos/contacts:latest
+        image: gcr.io/bank-of-anthos-ci/contacts:latest
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/dev-kubernetes-manifests/frontend.yaml
+++ b/dev-kubernetes-manifests/frontend.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos/frontend:latest
+        image: gcr.io/bank-of-anthos-ci/frontend:latest
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/dev-kubernetes-manifests/ledger-db.yaml
+++ b/dev-kubernetes-manifests/ledger-db.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: postgres
-          image: gcr.io/bank-of-anthos/ledger-db:latest
+          image: gcr.io/bank-of-anthos-ci/ledger-db:latest
           ports:
             - containerPort: 5432
           envFrom:

--- a/dev-kubernetes-manifests/ledger-writer.yaml
+++ b/dev-kubernetes-manifests/ledger-writer.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos/ledgerwriter:latest
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:latest
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/dev-kubernetes-manifests/loadgenerator.yaml
+++ b/dev-kubernetes-manifests/loadgenerator.yaml
@@ -32,7 +32,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos/loadgenerator:latest
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:latest
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/dev-kubernetes-manifests/transaction-history.yaml
+++ b/dev-kubernetes-manifests/transaction-history.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos/transactionhistory:latest
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:latest
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/dev-kubernetes-manifests/userservice.yaml
+++ b/dev-kubernetes-manifests/userservice.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos/userservice:latest
+        image: gcr.io/bank-of-anthos-ci/userservice:latest
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,8 +66,8 @@ Events:
   ----     ------       ----               ----                                             -------
   Normal   Scheduled    73s                default-scheduler                                Successfully assigned default/balancereader-fb6784fc-9fw2k to gke-toggles-default-pool-28882412-xljt
   Warning  FailedMount  72s (x2 over 72s)  kubelet, gke-toggles-default-pool-28882412-xljt  MountVolume.SetUp failed for volume "publickey" : secret "jwt-key" not found
-  Normal   Pulling      70s                kubelet, gke-toggles-default-pool-28882412-xljt  Pulling image "gcr.io/my-cool-project/bank-of-anthos/gcr.io/bank-of-anthos/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
-  Normal   Pulled       69s                kubelet, gke-toggles-default-pool-28882412-xljt  Successfully pulled image "gcr.io/my-cool-projectt/bank-of-anthos/gcr.io/bank-of-anthos/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
+  Normal   Pulling      70s                kubelet, gke-toggles-default-pool-28882412-xljt  Pulling image "gcr.io/my-cool-project/bank-of-anthos/gcr.io/bank-of-anthos-ci/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
+  Normal   Pulled       69s                kubelet, gke-toggles-default-pool-28882412-xljt  Successfully pulled image "gcr.io/my-cool-projectt/bank-of-anthos/gcr.io/bank-of-anthos-ci/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
   Normal   Created      69s                kubelet, gke-toggles-default-pool-28882412-xljt  Created container balancereader
   Normal   Started      69s                kubelet, gke-toggles-default-pool-28882412-xljt  Started container balancereader
   Warning  Unhealthy    4s (x2 over 9s)    kubelet, gke-toggles-default-pool-28882412-xljt  Readiness probe failed: Get http://10.0.1.141:8080/ready: dial tcp 10.0.1.141:8080: connect: connection refused

--- a/extras/cloudsql/kubernetes-manifests/balance-reader.yaml
+++ b/extras/cloudsql/kubernetes-manifests/balance-reader.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.0"
+          value: "v0.5.1"
         - name: PORT
           value: "8080"
         # toggle Cloud Trace export

--- a/extras/cloudsql/kubernetes-manifests/balance-reader.yaml
+++ b/extras/cloudsql/kubernetes-manifests/balance-reader.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos/balancereader:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.0
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/extras/cloudsql/kubernetes-manifests/contacts.yaml
+++ b/extras/cloudsql/kubernetes-manifests/contacts.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.0"
+          value: "v0.5.1"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/kubernetes-manifests/contacts.yaml
+++ b/extras/cloudsql/kubernetes-manifests/contacts.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos/contacts:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.0
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/extras/cloudsql/kubernetes-manifests/frontend.yaml
+++ b/extras/cloudsql/kubernetes-manifests/frontend.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos/frontend:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.0
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/extras/cloudsql/kubernetes-manifests/frontend.yaml
+++ b/extras/cloudsql/kubernetes-manifests/frontend.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.0"
+          value: "v0.5.1"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/kubernetes-manifests/ledger-writer.yaml
+++ b/extras/cloudsql/kubernetes-manifests/ledger-writer.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.0"
+          value: "v0.5.1"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/kubernetes-manifests/ledger-writer.yaml
+++ b/extras/cloudsql/kubernetes-manifests/ledger-writer.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos/ledgerwriter:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.0
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/extras/cloudsql/kubernetes-manifests/loadgenerator.yaml
+++ b/extras/cloudsql/kubernetes-manifests/loadgenerator.yaml
@@ -32,7 +32,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.1
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/extras/cloudsql/kubernetes-manifests/loadgenerator.yaml
+++ b/extras/cloudsql/kubernetes-manifests/loadgenerator.yaml
@@ -32,7 +32,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos/loadgenerator:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.0
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/extras/cloudsql/kubernetes-manifests/transaction-history.yaml
+++ b/extras/cloudsql/kubernetes-manifests/transaction-history.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.0"
+          value: "v0.5.1"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/kubernetes-manifests/transaction-history.yaml
+++ b/extras/cloudsql/kubernetes-manifests/transaction-history.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos/transactionhistory:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.0
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/extras/cloudsql/kubernetes-manifests/userservice.yaml
+++ b/extras/cloudsql/kubernetes-manifests/userservice.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos/userservice:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.0
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"

--- a/extras/cloudsql/kubernetes-manifests/userservice.yaml
+++ b/extras/cloudsql/kubernetes-manifests/userservice.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.0
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.1
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"
@@ -39,7 +39,7 @@ spec:
           containerPort: 8080
         env:
         - name: VERSION
-          value: "v0.5.0"
+          value: "v0.5.1"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/kubernetes-manifests/accounts-db.yaml
+++ b/kubernetes-manifests/accounts-db.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: accounts-db
-        image: gcr.io/bank-of-anthos/accounts-db:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/accounts-db:v0.5.1
         envFrom:
           - configMapRef:
               name: environment-config

--- a/kubernetes-manifests/balance-reader.yaml
+++ b/kubernetes-manifests/balance-reader.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos/balancereader:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/kubernetes-manifests/contacts.yaml
+++ b/kubernetes-manifests/contacts.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos/contacts:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos/frontend:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/kubernetes-manifests/ledger-db.yaml
+++ b/kubernetes-manifests/ledger-db.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: postgres
-          image: gcr.io/bank-of-anthos/ledger-db:v0.5.1
+          image: gcr.io/bank-of-anthos-ci/ledger-db:v0.5.1
           ports:
             - containerPort: 5432
           envFrom:

--- a/kubernetes-manifests/ledger-writer.yaml
+++ b/kubernetes-manifests/ledger-writer.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos/ledgerwriter:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -32,7 +32,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos/loadgenerator:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.1
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/kubernetes-manifests/transaction-history.yaml
+++ b/kubernetes-manifests/transaction-history.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos/transactionhistory:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.1
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/kubernetes-manifests/userservice.yaml
+++ b/kubernetes-manifests/userservice.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos/userservice:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.1
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"


### PR DESCRIPTION
This PR changes the K8s image refs to use the new `bank-of-anthos-ci` project.

The images were copied over using:
```
#!/bin/bash
for service in accounts-db balancereader contacts frontend ledger-db ledgerwriter loadgenerator transactionhistory userservice
do
    for version in v0.1.0 v0.1.1 v0.1.2 v0.2.0 v0.3.0 v0.3.1 v0.4.0 v0.4.1 v0.4.2 v0.4.3 v0.5.0 v0.5.1
    do
        docker pull gcr.io/bank-of-anthos/$service:$version
        docker tag gcr.io/bank-of-anthos/$service:$version gcr.io/bank-of-anthos-ci/$service:$version
        docker push gcr.io/bank-of-anthos-ci/$service:$version
    done
done
```

I've tested by deploying the latest release to a new cluster:
```
kubectl apply -f ./kubernetes-manifests
```

And looked at the services to see that it was using one of the newly migrated images / tags (in this case `v0.5.1`):
```
NAME                                 READY   STATUS    RESTARTS   AGE
accounts-db-0                        1/1     Running   0          2m11s
balancereader-f65588d7f-smsd7        1/1     Running   0          2m19s
contacts-777ff878f9-gktw6            1/1     Running   0          2m19s
frontend-6cf6c4fc4c-z7tbt            1/1     Running   0          2m19s
ledger-db-0                          1/1     Running   0          2m14s
ledgerwriter-59c6cb98b8-b7jt8        1/1     Running   0          2m19s
loadgenerator-84c879784d-kt4jh       1/1     Running   0          2m19s
transactionhistory-5569fbcb7-nmd2m   1/1     Running   0          2m18s
userservice-87d596bc8-rshw5          1/1     Running   0          2m18s
```

```
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  35s   default-scheduler  Successfully assigned default/accounts-db-0 to gke-cluster-1-default-pool-8a61a383-5s6n
  Normal  Pulling    33s   kubelet            Pulling image "gcr.io/bank-of-anthos-ci/accounts-db:v0.5.1"
  Normal  Pulled     8s    kubelet            Successfully pulled image "gcr.io/bank-of-anthos-ci/accounts-db:v0.5.1" in 25.3857518s
  Normal  Created    6s    kubelet            Created container accounts-db
  Normal  Started    6s    kubelet            Started container accounts-db
```