### PR TITLE
Enable pip-compile support in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "pip-compile": {
+    "enabled": true,
+    "fileMatch": ["(^|/)requirements\\.in$"]
+  }
 }


### PR DESCRIPTION
This PR enables the `pip-compile` module for Renovate, based on this doc: https://docs.renovatebot.com/modules/manager/pip-compile/

This is due to our usage of `pip-compile` to pin dependencies in our python code. Renovate does not have `pip-compile` by default, which means that currently it skips the `.in` files and modifies the `.txt` requirements directly.