### PR TITLE
Delete checkout step from cleanup workflows

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -25,7 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Delete PR namespace in staging cluster
         if: ${{ always() }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -23,9 +23,6 @@ jobs:
   cleanup-namespace:
     runs-on: [self-hosted, runners-v2]
     steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Delete PR namespace in staging cluster
         if: ${{ always() }}
         timeout-minutes: 20


### PR DESCRIPTION
This PR removes the checkout step from the cleanup workflows. None of the cleanup steps require checking in, and attempting to do so yields errors if the branch was deleted before the cleanup job started running (race condition): https://github.com/GoogleCloudPlatform/bank-of-anthos/actions/workflows/cleanup.yaml

I will test this by deleting the branch immediately following merging.