### PR TITLE
Fix Skaffold always pulling canonical images

### DIFF
--- a/dev-kubernetes-manifests/accounts-db.yaml
+++ b/dev-kubernetes-manifests/accounts-db.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: accounts-db
-        image: gcr.io/bank-of-anthos-ci/accounts-db:latest
+        image: accounts-db
         envFrom:
           - configMapRef:
               name: environment-config

--- a/dev-kubernetes-manifests/balance-reader.yaml
+++ b/dev-kubernetes-manifests/balance-reader.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos-ci/balancereader:latest
+        image: balancereader
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.2.0"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         # toggle Cloud Trace export

--- a/dev-kubernetes-manifests/contacts.yaml
+++ b/dev-kubernetes-manifests/contacts.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos-ci/contacts:latest
+        image: contacts
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.2.0"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/dev-kubernetes-manifests/frontend.yaml
+++ b/dev-kubernetes-manifests/frontend.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos-ci/frontend:latest
+        image: frontend
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.2.0"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/dev-kubernetes-manifests/ledger-db.yaml
+++ b/dev-kubernetes-manifests/ledger-db.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: postgres
-          image: gcr.io/bank-of-anthos-ci/ledger-db:latest
+          image: ledger-db
           ports:
             - containerPort: 5432
           envFrom:

--- a/dev-kubernetes-manifests/ledger-writer.yaml
+++ b/dev-kubernetes-manifests/ledger-writer.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos-ci/ledgerwriter:latest
+        image: ledgerwriter
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.2.0"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/dev-kubernetes-manifests/loadgenerator.yaml
+++ b/dev-kubernetes-manifests/loadgenerator.yaml
@@ -34,7 +34,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos-ci/loadgenerator:latest
+        image: loadgenerator
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/dev-kubernetes-manifests/transaction-history.yaml
+++ b/dev-kubernetes-manifests/transaction-history.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos-ci/transactionhistory:latest
+        image: transactionhistory
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.2.0"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/dev-kubernetes-manifests/userservice.yaml
+++ b/dev-kubernetes-manifests/userservice.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos-ci/userservice:latest
+        image: userservice
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"
@@ -40,7 +40,7 @@ spec:
           containerPort: 8080
         env:
         - name: VERSION
-          value: "v0.2.0"
+          value: "v0.5.3"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/kubernetes-manifests/accounts-db.yaml
+++ b/kubernetes-manifests/accounts-db.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_boa_kubernetes_manifests_accounts_db_statefulset_accounts_db]
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -60,7 +61,9 @@ spec:
       volumes:
       - name: postgresdb
         emptyDir: {}
+# [END gke_boa_kubernetes_manifests_accounts_db_statefulset_accounts_db]
 ---
+# [START gke_boa_kubernetes_manifests_accounts_db_service_accounts_db]
 apiVersion: v1
 kind: Service
 metadata:
@@ -77,7 +80,9 @@ spec:
   selector:
     app: accounts-db
     tier: db
+# [END gke_boa_kubernetes_manifests_accounts_db_service_accounts_db]
 ---
+# [START gke_boa_kubernetes_manifests_accounts_db_configmap_accounts_db_config]
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -89,3 +94,4 @@ data:
   POSTGRES_USER: accounts-admin
   POSTGRES_PASSWORD: accounts-pwd
   ACCOUNTS_DB_URI: postgresql://accounts-admin:accounts-pwd@accounts-db:5432/accounts-db
+# [END gke_boa_kubernetes_manifests_accounts_db_configmap_accounts_db_config]

--- a/kubernetes-manifests/balance-reader.yaml
+++ b/kubernetes-manifests/balance-reader.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_boa_kubernetes_manifests_balance_reader_deployment_balancereader]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -93,7 +94,9 @@ spec:
           items:
           - key: jwtRS256.key.pub
             path: publickey
+# [END gke_boa_kubernetes_manifests_balance_reader_deployment_balancereader]
 ---
+# [START gke_boa_kubernetes_manifests_balance_reader_service_balancereader]
 apiVersion: v1
 kind: Service
 metadata:
@@ -106,3 +109,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
+# [END gke_boa_kubernetes_manifests_balance_reader_service_balancereader]

--- a/kubernetes-manifests/config.yaml
+++ b/kubernetes-manifests/config.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_boa_kubernetes_manifests_config_configmap_environment_config]
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,7 +20,9 @@ metadata:
 data:
   LOCAL_ROUTING_NUM: "883745000"
   PUB_KEY_PATH: "/root/.ssh/publickey"
+# [END gke_boa_kubernetes_manifests_config_configmap_environment_config]
 ---
+# [START gke_boa_kubernetes_manifests_config_configmap_service_api_config]
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -30,7 +33,9 @@ data:
   HISTORY_API_ADDR: "transactionhistory:8080"
   CONTACTS_API_ADDR: "contacts:8080"
   USERSERVICE_API_ADDR: "userservice:8080"
+# [END gke_boa_kubernetes_manifests_config_configmap_service_api_config]
 ---
+# [START gke_boa_kubernetes_manifests_config_configmap_demo_data_config]
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -40,3 +45,4 @@ data:
   DEMO_LOGIN_USERNAME: "testuser"
   # All demo user accounts are hardcoded to use the login password 'password'
   DEMO_LOGIN_PASSWORD: "password"
+# [END gke_boa_kubernetes_manifests_config_configmap_demo_data_config]

--- a/kubernetes-manifests/contacts.yaml
+++ b/kubernetes-manifests/contacts.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_boa_kubernetes_manifests_contacts_deployment_contacts]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,7 +72,9 @@ spec:
           items:
           - key: jwtRS256.key.pub
             path: publickey
+# [END gke_boa_kubernetes_manifests_contacts_deployment_contacts]
 ---
+# [START gke_boa_kubernetes_manifests_contacts_service_contacts]
 apiVersion: v1
 kind: Service
 metadata:
@@ -84,3 +87,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
+# [END gke_boa_kubernetes_manifests_contacts_service_contacts]

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_boa_kubernetes_manifests_frontend_deployment_frontend]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -95,7 +96,9 @@ spec:
           items:
           - key: jwtRS256.key.pub
             path: publickey
+# [END gke_boa_kubernetes_manifests_frontend_deployment_frontend]
 ---
+# [START gke_boa_kubernetes_manifests_frontend_service_frontend]
 apiVersion: v1
 kind: Service
 metadata:
@@ -108,3 +111,4 @@ spec:
   - name: http
     port: 80
     targetPort: 8080
+# [END gke_boa_kubernetes_manifests_frontend_service_frontend]

--- a/kubernetes-manifests/ledger-db.yaml
+++ b/kubernetes-manifests/ledger-db.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_boa_kubernetes_manifests_ledger_db_statefulset_ledger_db]
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -54,7 +55,9 @@ spec:
       volumes:
         - name: postgresdb
           emptyDir: {}
+# [END gke_boa_kubernetes_manifests_ledger_db_statefulset_ledger_db]
 ---
+# [START gke_boa_kubernetes_manifests_ledger_db_configmap_ledger_db_config]
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -68,7 +71,9 @@ data:
   SPRING_DATASOURCE_URL: jdbc:postgresql://ledger-db:5432/postgresdb
   SPRING_DATASOURCE_USERNAME: admin # should match POSTGRES_USER
   SPRING_DATASOURCE_PASSWORD: password # should match POSTGRES_PASSWORD
+# [END gke_boa_kubernetes_manifests_ledger_db_configmap_ledger_db_config]
 ---
+# [START gke_boa_kubernetes_manifests_ledger_db_service_ledger_db]
 apiVersion: v1
 kind: Service
 metadata:
@@ -81,3 +86,4 @@ spec:
   - name: tcp
     port: 5432
     targetPort: 5432
+# [END gke_boa_kubernetes_manifests_ledger_db_service_ledger_db]

--- a/kubernetes-manifests/ledger-writer.yaml
+++ b/kubernetes-manifests/ledger-writer.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_boa_kubernetes_manifests_ledger_writer_deployment_ledgerwriter]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,7 +83,9 @@ spec:
           items:
           - key: jwtRS256.key.pub
             path: publickey
+# [END gke_boa_kubernetes_manifests_ledger_writer_deployment_ledgerwriter]
 ---
+# [START gke_boa_kubernetes_manifests_ledger_writer_service_ledgerwriter]
 apiVersion: v1
 kind: Service
 metadata:
@@ -95,3 +98,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
+# [END gke_boa_kubernetes_manifests_ledger_writer_service_ledgerwriter]

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_loadgenerator_deployment_loadgenerator]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -47,3 +49,4 @@ spec:
           limits:
             cpu: 500m
             memory: 1Gi
+# [END gke_boa_kubernetes_manifests_loadgenerator_deployment_loadgenerator]

--- a/kubernetes-manifests/transaction-history.yaml
+++ b/kubernetes-manifests/transaction-history.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_boa_kubernetes_manifests_transaction_history_deployment_transactionhistory]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -98,7 +99,9 @@ spec:
           items:
           - key: jwtRS256.key.pub
             path: publickey
+# [END gke_boa_kubernetes_manifests_transaction_history_deployment_transactionhistory]
 ---
+# [START gke_boa_kubernetes_manifests_transaction_history_service_transactionhistory]
 apiVersion: v1
 kind: Service
 metadata:
@@ -111,3 +114,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
+# [END gke_boa_kubernetes_manifests_transaction_history_service_transactionhistory]

--- a/kubernetes-manifests/userservice.yaml
+++ b/kubernetes-manifests/userservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_boa_kubernetes_manifests_userservice_deployment_userservice]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -79,9 +80,9 @@ spec:
             path: privatekey
           - key: jwtRS256.key.pub
             path: publickey
-
-
+# [END gke_boa_kubernetes_manifests_userservice_deployment_userservice]
 ---
+# [START gke_boa_kubernetes_manifests_userservice_service_userservice]
 apiVersion: v1
 kind: Service
 metadata:
@@ -94,3 +95,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
+# [END gke_boa_kubernetes_manifests_userservice_service_userservice]

--- a/release/make-release.sh
+++ b/release/make-release.sh
@@ -30,18 +30,18 @@ if [[ ! "${NEW_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
-# # ensure there are no uncommitted changes
-# if [[ $(git status -s | wc -l) -gt 0 ]]; then
-#     echo "error: can't have uncommitted changes"
-#     exit 1
-# fi
+# ensure there are no uncommitted changes
+if [[ $(git status -s | wc -l) -gt 0 ]]; then
+    echo "error: can't have uncommitted changes"
+    exit 1
+fi
 
-# # ensure that gcloud is in the PATH
-# if ! command -v gcloud &> /dev/null
-# then
-#     echo "gcloud could not be found"
-#     exit 1
-# fi
+# ensure that gcloud is in the PATH
+if ! command -v gcloud &> /dev/null
+then
+    echo "gcloud could not be found"
+    exit 1
+fi
 
 # replace kubernetes-manifests/ contents 
 rm -rf "${REPO_ROOT}/kubernetes-manifests"
@@ -54,19 +54,19 @@ find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s'image
 # remove the region tags so that there are no duplicates 
 find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e  "s/dev_kubernetes_manifests/boa_kubernetes_manifests/g" {} \;
 
-# # push release PR
-# git checkout -b "release/${NEW_VERSION}"
-# git add "${REPO_ROOT}/kubernetes-manifests/*.yaml"
-# git commit -m "release/${NEW_VERSION}"
+# push release PR
+git checkout -b "release/${NEW_VERSION}"
+git add "${REPO_ROOT}/kubernetes-manifests/*.yaml"
+git commit -m "release/${NEW_VERSION}"
 
-# # add tag
-# git tag "${NEW_VERSION}"
+# add tag
+git tag "${NEW_VERSION}"
 
-# # build and push release images
-# skaffold config set local-cluster false
-# skaffold build --default-repo="${REPO_PREFIX}" --tag="${NEW_VERSION}"
-# skaffold config unset local-cluster
+# build and push release images
+skaffold config set local-cluster false
+skaffold build --default-repo="${REPO_PREFIX}" --tag="${NEW_VERSION}"
+skaffold config unset local-cluster
 
-# # push to repo
-# git push --set-upstream origin "release/${NEW_VERSION}"
-# git push --tags
+# push to repo
+git push --set-upstream origin "release/${NEW_VERSION}"
+git push --tags

--- a/release/make-release.sh
+++ b/release/make-release.sh
@@ -30,18 +30,18 @@ if [[ ! "${NEW_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
-# ensure there are no uncommitted changes
-if [[ $(git status -s | wc -l) -gt 0 ]]; then
-    echo "error: can't have uncommitted changes"
-    exit 1
-fi
+# # ensure there are no uncommitted changes
+# if [[ $(git status -s | wc -l) -gt 0 ]]; then
+#     echo "error: can't have uncommitted changes"
+#     exit 1
+# fi
 
-# ensure that gcloud is in the PATH
-if ! command -v gcloud &> /dev/null
-then
-    echo "gcloud could not be found"
-    exit 1
-fi
+# # ensure that gcloud is in the PATH
+# if ! command -v gcloud &> /dev/null
+# then
+#     echo "gcloud could not be found"
+#     exit 1
+# fi
 
 # replace kubernetes-manifests/ contents 
 rm -rf "${REPO_ROOT}/kubernetes-manifests"
@@ -49,27 +49,24 @@ mkdir "${REPO_ROOT}/kubernetes-manifests"
 cp -a "${REPO_ROOT}/dev-kubernetes-manifests/." "${REPO_ROOT}/kubernetes-manifests/"
 
 # update version in manifests
-CURRENT_VERSION=$(grep -A 1 VERSION ${REPO_ROOT}/kubernetes-manifests/*.yaml | grep value | head -n 1 | awk '{print $3}' |  tr -d '"')
-find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s/${CURRENT_VERSION}/${NEW_VERSION}/g" {} \;
-# # tag image with explicit version
-find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s/:latest/:${NEW_VERSION}/g" {} \;
+find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s'image: \(.*\)'image: ${REPO_PREFIX}\/\1:${NEW_VERSION}'g" {} \;
 
 # remove the region tags so that there are no duplicates 
 find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e  "s/dev_kubernetes_manifests/boa_kubernetes_manifests/g" {} \;
 
-# push release PR
-git checkout -b "release/${NEW_VERSION}"
-git add "${REPO_ROOT}/kubernetes-manifests/*.yaml"
-git commit -m "release/${NEW_VERSION}"
+# # push release PR
+# git checkout -b "release/${NEW_VERSION}"
+# git add "${REPO_ROOT}/kubernetes-manifests/*.yaml"
+# git commit -m "release/${NEW_VERSION}"
 
-# add tag
-git tag "${NEW_VERSION}"
+# # add tag
+# git tag "${NEW_VERSION}"
 
-# build and push release images
-skaffold config set local-cluster false
-skaffold build --default-repo="${REPO_PREFIX}" --tag="${NEW_VERSION}"
-skaffold config unset local-cluster
+# # build and push release images
+# skaffold config set local-cluster false
+# skaffold build --default-repo="${REPO_PREFIX}" --tag="${NEW_VERSION}"
+# skaffold config unset local-cluster
 
-# push to repo
-git push --set-upstream origin "release/${NEW_VERSION}"
-git push --tags
+# # push to repo
+# git push --set-upstream origin "release/${NEW_VERSION}"
+# git push --tags

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -44,4 +44,4 @@ RUN pip install -r /app/requirements.txt
 ADD locustfile.py /app
 
 # start loadgenerator
-ENTRYPOINT locust --host="http://${FRONTEND_ADDR}" --loglevel $LOG_LEVEL --no-web -c "${USERS:-10}" 2>&1
+ENTRYPOINT locust --host="http://${FRONTEND_ADDR}" --loglevel $LOG_LEVEL --headless --users="${USERS:-10}" 2>&1


### PR DESCRIPTION
I noticed that when using `skaffold dev/run` with modified source, Skaffold would generate and tag images as expected, but the resulting deployment was using `gcr.io/bank-of-anthos-ci` (i.e. canonical) images instead of the built ones. The culprit seems to be https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/595.

Example:

```
~ skaffold run --default-repo=gcr.io/<project-id>/bank-of-anthos
. . .
. . .
Tags used in deployment:
 - accounts-db -> gcr.io/<project-id>/bank-of-anthos/accounts-db:v0.5.1-75-ge434f66@sha256:b28260f834772a1b6eb49cc4a5c843d5f536512d7d6fa59aa0a354b128437d31
 - ledger-db -> gcr.io/<project-id>/bank-of-anthos/ledger-db:v0.5.1-75-ge434f66@sha256:cb852952e32d7c32d63ff360e3359ccc94731a19696975651f7e4c9eb14cf530
 - ledgerwriter -> gcr.io/<project-id>/bank-of-anthos/ledgerwriter:v0.5.1-75-ge434f66-dirty@sha256:988f4ee55048cb21019ff7d2c61ce34dd5d4044980bf00fe628053f743c49195
 - balancereader -> gcr.io/<project-id>/bank-of-anthos/balancereader:v0.5.1-75-ge434f66-dirty@sha256:a94889fa8d21bdba789d59f00dde15d0661ac8eef9c6a899bd1b045b50f0e0b7
 - transactionhistory -> gcr.io/<project-id>/bank-of-anthos/transactionhistory:v0.5.1-75-ge434f66-dirty@sha256:f9ae27bcbe842dc3f802ee3bdedd92913613de483669d678731ddb3477090404
 - contacts -> gcr.io/<project-id>/bank-of-anthos/contacts:v0.5.1-75-ge434f66@sha256:b04db5e370f4bbdf0f84534e5aeb93dc771ba7d4411c80150feb8ee1295f69ed
 - userservice -> gcr.io/<project-id>/bank-of-anthos/userservice:v0.5.1-75-ge434f66@sha256:15e6eea6b790cccd43ad5306e048edc5d1b62fab6e01474369ea9024acec16a0
 - frontend -> gcr.io/<project-id>/bank-of-anthos/frontend:v0.5.1-75-ge434f66@sha256:fd6c774418247184b69a7e6ead69986a13c4ab66436f1474477008d0b15a91a4
 - loadgenerator -> gcr.io/<project-id>/bank-of-anthos/loadgenerator:v0.5.1-75-ge434f66@sha256:4a787e94898878cad47fd4d91e3d8a903f242f0304b15292f8b10781027dc983
Starting deploy...
. . .
. . .
```

```
~ kubectl get pods -o json | grep image\"

    "image": "gcr.io/bank-of-anthos-ci/accounts-db:latest",
    "image": "gcr.io/bank-of-anthos-ci/accounts-db:latest",
    "image": "gcr.io/bank-of-anthos-ci/balancereader:latest",
    "image": "gcr.io/bank-of-anthos-ci/balancereader:latest",
    "image": "gcr.io/bank-of-anthos-ci/contacts:latest",
    "image": "gcr.io/bank-of-anthos-ci/contacts:latest",
    "image": "gcr.io/bank-of-anthos-ci/frontend:latest",
    "image": "gcr.io/bank-of-anthos-ci/frontend:latest",
    "image": "gcr.io/bank-of-anthos-ci/ledger-db:latest",
    "image": "gcr.io/bank-of-anthos-ci/ledger-db:latest",
    "image": "gcr.io/bank-of-anthos-ci/ledgerwriter:latest",
    "image": "gcr.io/bank-of-anthos-ci/ledgerwriter:latest",
    "image": "gcr.io/bank-of-anthos-ci/loadgenerator:latest",
    "image": "gcr.io/bank-of-anthos-ci/loadgenerator:latest",
    "image": "gcr.io/bank-of-anthos-ci/transactionhistory:latest",
    "image": "gcr.io/bank-of-anthos-ci/transactionhistory:latest",
    "image": "gcr.io/bank-of-anthos-ci/userservice:latest",
    "image": "gcr.io/bank-of-anthos-ci/userservice:latest",
```

My intuition is that Skaffold is looking to replace images that matches 100%, and there's currently (since #595) a mismatch with e.g. `frontend` from the Skaffold config with `gcr.io/bank-of-anthos-ci/frontend:latest` from the `dev-kubernetes-manifests/`. Instead of reverting that PR, I'm creating this new PR to solve the issue by substituting all images with their service name instead (removing the tag and the repo prefix entirely).

I have tested this by deploying using `skaffold run --default-repo=gcr.io/<project-id>/bank-of-anthos`

```
~ kubectl get pods -o json | grep image\"

    "image": "gcr.io/<project-id>/bank-of-anthos/accounts-db:v0.5.1-75-ge434f66@sha256:b28260f834772a1b6eb49cc4a5c843d5f536512d7d6fa59aa0a354b128437d31",
    "image": "sha256:a0c5c4403becc6606282fa4476905703f1c624f61ca43b8359d474aef2404371",
    "image": "gcr.io/<project-id>/bank-of-anthos/balancereader:v0.5.1-75-ge434f66-dirty@sha256:a94889fa8d21bdba789d59f00dde15d0661ac8eef9c6a899bd1b045b50f0e0b7",
    "image": "gcr.io/bank-of-anthos-ci/balancereader:latest",
    "image": "gcr.io/<project-id>/bank-of-anthos/contacts:v0.5.1-75-ge434f66@sha256:b04db5e370f4bbdf0f84534e5aeb93dc771ba7d4411c80150feb8ee1295f69ed",
    "image": "sha256:0e4536869945023a94ae20b8c03ce5a5fc714290f3c50a7492298b00ff5e967b",
    "image": "gcr.io/<project-id>/bank-of-anthos/frontend:v0.5.1-75-ge434f66@sha256:fd6c774418247184b69a7e6ead69986a13c4ab66436f1474477008d0b15a91a4",
    "image": "sha256:31938d0eee9ca2acf232e6d230582c1c0be6f407a7b583d6197bad1287d9564f",
    "image": "gcr.io/<project-id>/bank-of-anthos/ledger-db:v0.5.1-75-ge434f66@sha256:cb852952e32d7c32d63ff360e3359ccc94731a19696975651f7e4c9eb14cf530",
    "image": "sha256:060c49146858eca28dbb13c7934a779529ff9b32e12b6fc8bb065a402389d44b",
    "image": "gcr.io/<project-id>/bank-of-anthos/ledgerwriter:v0.5.1-75-ge434f66-dirty@sha256:988f4ee55048cb21019ff7d2c61ce34dd5d4044980bf00fe628053f743c49195",
    "image": "gcr.io/bank-of-anthos-ci/ledgerwriter:latest",
    "image": "gcr.io/<project-id>/bank-of-anthos/loadgenerator:v0.5.1-75-ge434f66@sha256:4a787e94898878cad47fd4d91e3d8a903f242f0304b15292f8b10781027dc983",
    "image": "sha256:c620dd5910121ebb5a0c159c000e3492ca1ff087b46c0bf99894b2a84629fe00",
    "image": "gcr.io/<project-id>/bank-of-anthos/transactionhistory:v0.5.1-75-ge434f66-dirty@sha256:f9ae27bcbe842dc3f802ee3bdedd92913613de483669d678731ddb3477090404",
    "image": "gcr.io/bank-of-anthos-ci/transactionhistory:latest",
    "image": "gcr.io/<project-id>/bank-of-anthos/userservice:v0.5.1-75-ge434f66@sha256:15e6eea6b790cccd43ad5306e048edc5d1b62fab6e01474369ea9024acec16a0",
    "image": "sha256:307a1f91321c015310da06f69928b879b7804597e1ac27b722aa86ce02ee4e4b",
```