### PR TITLE
Revert "fix(deps): update dependency com.auth0:java-jwt to v3.18.3 (#…

### DIFF
--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.18.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.18.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.18.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.18.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This PR reverts commit 4f69351bd0e4734c5a2febfd8c2976ccbdf55e1f.

The original PR (https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/641) had passing checks but I'm suspecting that it may have been a false positive. All tests are failing since this commit went in (including brand new PRs based on the main branch).

If this PRs tests passes, then the bump was the culprit.