### PR TITLE
Revert recent Renovate Java deps bumps

### DIFF
--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>5.3.7.RELEASE</version>
+            <version>5.2.1.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.3.1.RELEASE</version>
     </parent>
 
     <properties>

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.18.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.3.1.RELEASE</version>
     </parent>
 
     <properties>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>5.3.7.RELEASE</version>
+            <version>5.2.1.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.18.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>5.3.7.RELEASE</version>
+            <version>5.2.1.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.3.1.RELEASE</version>
     </parent>
 
     <properties>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.18.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>5.3.7.RELEASE</version>
+            <version>5.2.1.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.3.1.RELEASE</version>
     </parent>
 
     <properties>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.18.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Since the main branch is currently failing, this PR reverts:
- https://github.com/GoogleCloudPlatform/bank-of-anthos/commit/ea8822461f4533dfb2df0505847c8110bad5d971
- https://github.com/GoogleCloudPlatform/bank-of-anthos/commit/3f628543f727b61ea3f021fca6ac0e3feebf8388
- https://github.com/GoogleCloudPlatform/bank-of-anthos/commit/4f69351bd0e4734c5a2febfd8c2976ccbdf55e1f
- https://github.com/GoogleCloudPlatform/bank-of-anthos/commit/60d9955b7222ff41cd13fb677ba79c48e6ed8c9f

I tried to revert one at a time for each of them but they were all broken in different ways; likely they need some source code changes. I'll differ them to a later dependency bump unless we get a security notice targeting those dependencies in particular.