### PR TITLE
Added python constraint to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
   "pip-compile": {
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"]
+  },
+  "constraints": {
+    "python": "3.7"
   }
 }


### PR DESCRIPTION
### Background 
Seeing that renovate-bot was using python10 for pip-compile

### Change Summary
Added constraint to python3.7 in renovate.json (see the [docs](https://docs.renovatebot.com/modules/manager/pip-compile/))

### Additional Notes
n/a

### Testing Procedure
Ensure that renovate-bot isn't using the latest python when preparing PRs

### Related PRs or Issues 
https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/650
