### PR TITLE
Disable pip_requirements for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"]
   },
+  "pip_requirements": {
+    "enabled": false
+  },
   "constraints": {
     "python": "3.7"
   }


### PR DESCRIPTION
This PR disables `pip-requirements` for Renovate, which clashed with the `pip-compile` plugin. More details here: https://github.com/GoogleCloudPlatform/microservices-demo/pull/764