### PR TITLE
Revert "Disable pip-requirements for renovate (#669)"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,6 @@
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"]
   },
-  "pip_requirements": {
-    "enabled": false
-  },
   "constraints": {
     "python": "3.7"
   }


### PR DESCRIPTION
This PR reverts #669 since PRs are getting created without any changes to the `.txt` file, e.g.: https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/675/files