### PR TITLE
Added pep440 contraint to renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,6 @@
     "fileMatch": ["(^|/)requirements\\.in$"]
   },
   "constraints": {
-    "python": "3.7"
+    "python": "3.7.0"
   }
 }


### PR DESCRIPTION
### Fixes n/a

### Background 
I saw in the DEBUG logs that renovate bot was not able to pull docker images for 3.7. Per the maintainers discussion [here](https://github.com/renovatebot/renovate/discussions/14588#discussioncomment-2326254), he suggested contraining to 3.7.0

### Change Summary
renovate.json python constraint now says `3.7.0`

### Additional Notes
n/a

### Testing Procedure
I'll keep an eye on the next debug logs when the PRs get rerun

### Related PRs or Issues 
