### PR TITLE
Constaint python and added config for renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,24 @@
     "fileMatch": ["(^|/)requirements\\.in$"]
   },
   "constraints": {
-    "python": "3.7.0"
+    "python": "~=3.7.0"
+  },
+  "prConcurrentLimit":5,
+  "stabilityDays":7,
+  "vulnerabilityAlerts":{
+     "labels":[
+       "type:security" 
+     ],
+     "stabilityDays":0
+  },
+  "labels": ["dependencies"],
+  "python":{
+    "addLabels": ["lang: python"]
+  },
+  "java":{
+    "addLabels": ["lang: java"]
+  },
+  "golang":{
+    "addLabels": ["lang: go"]
   }
 }


### PR DESCRIPTION
### Fixes n/a
### Background 
Applying some of the results of the team's survey. This is an example PR, but it adds stability days, concurrent PR limits, and adds config to bypass that if there is a security vulnerability. Also pins our python docker image to v3.7

### Change Summary
* Sets prConcurrentLimit to 5, stabilityDays to 7
* Sets both prConcurrentLimit and stabilityDays to 0 if it is a CVE is reported
* Also constrains python to 3.7 (before, even though it said "python":"3.7", it wasn't working. Followed up with the maintainer on why that was happening, but the solution was to use "python":"~=3.7.0" instead

### Additional Notes
Note: we also have dependabot (which is built into Github) to notify us of security vulnerabilities.

### Testing Procedure
na

### Related PRs or Issues 
Similar to https://github.com/GoogleCloudPlatform/microservices-demo/pull/780
