### PR TITLE
Bump Java dependencies to mitigate CVE-2022-22965

### DIFF
--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>25.0.0</version>
+                <version>25.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -69,12 +69,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-trace</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.19.0</version>
+            <version>3.19.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -158,7 +158,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.1</version>
                 <configuration>
                     <from>
                         <image>openjdk:17</image>

--- a/src/contacts/requirements.in
+++ b/src/contacts/requirements.in
@@ -23,7 +23,7 @@ Jinja2==2.11.3
 MarkupSafe==1.1.1
 more-itertools==8.12.0
 psycopg2==2.9.3
-sqlalchemy==1.4.32
+sqlalchemy==1.4.34
 opentelemetry-sdk==0.13b0
 opentelemetry-exporter-google-cloud==0.13b0
 opentelemetry-tools-google-cloud==0.13b0

--- a/src/contacts/requirements.txt
+++ b/src/contacts/requirements.txt
@@ -196,7 +196,7 @@ six==1.16.0
     #   google-auth
     #   google-cloud-core
     #   grpcio
-sqlalchemy==1.4.32
+sqlalchemy==1.4.34
     # via
     #   -r requirements.in
     #   opentelemetry-instrumentation-sqlalchemy

--- a/src/frontend/requirements.txt
+++ b/src/frontend/requirements.txt
@@ -125,7 +125,7 @@ six==1.16.0
     #   google-auth
     #   google-cloud-core
     #   grpcio
-sqlalchemy==1.4.32
+sqlalchemy==1.4.34
     # via opentelemetry-instrumentation-sqlalchemy
 urllib3==1.26.9
     # via

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>25.0.0</version>
+                <version>25.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -69,12 +69,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-trace</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.19.0</version>
+            <version>3.19.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.1</version>
                 <configuration>
                     <from>
                         <image>openjdk:17</image>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>25.0.0</version>
+                <version>25.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -69,12 +69,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-trace</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.19.0</version>
+            <version>3.19.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -148,7 +148,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.1</version>
                 <configuration>
                     <from>
                         <image>openjdk:17</image>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>25.0.0</version>
+                <version>25.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -69,12 +69,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-trace</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.19.0</version>
+            <version>3.19.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -158,7 +158,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.1</version>
                 <configuration>
                     <from>
                         <image>openjdk:17</image>

--- a/src/userservice/requirements.in
+++ b/src/userservice/requirements.in
@@ -43,7 +43,7 @@ pytz==2022.1
 requests==2.27.1
 rsa==4.8
 six==1.16.0
-sqlalchemy==1.4.32
+sqlalchemy==1.4.34
 urllib3==1.26.9
 wcwidth==0.2.5
 webencodings==0.5.1

--- a/src/userservice/requirements.txt
+++ b/src/userservice/requirements.txt
@@ -196,7 +196,7 @@ six==1.16.0
     #   google-auth
     #   google-cloud-core
     #   grpcio
-sqlalchemy==1.4.32
+sqlalchemy==1.4.34
     # via
     #   -r requirements.in
     #   opentelemetry-instrumentation-sqlalchemy


### PR DESCRIPTION
This PR bumps:
- `com.google.cloud.libraries-bom==25.1.0`
- `com.google.cloud.spring-cloud-gcp-starter==3.2.0`
- `com.google.cloud.spring-cloud-gcp-starter-trace==3.2.0`
- `com.auth0.java-jwt==3.19.1`
- `com.google.cloud.tools.jib-maven-plugin==3.2.1`
- `sqlalchemy==1.4.34`

In part to mitigate: https://tanzu.vmware.com/security/cve-2022-22965