### PR TITLE
Substitute version env correctly on release

### DIFF
--- a/dev-kubernetes-manifests/balance-reader.yaml
+++ b/dev-kubernetes-manifests/balance-reader.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "dev"
         - name: PORT
           value: "8080"
         # toggle Cloud Trace export

--- a/dev-kubernetes-manifests/contacts.yaml
+++ b/dev-kubernetes-manifests/contacts.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "dev"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/dev-kubernetes-manifests/frontend.yaml
+++ b/dev-kubernetes-manifests/frontend.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "dev"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/dev-kubernetes-manifests/ledger-writer.yaml
+++ b/dev-kubernetes-manifests/ledger-writer.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "dev"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/dev-kubernetes-manifests/transaction-history.yaml
+++ b/dev-kubernetes-manifests/transaction-history.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "dev"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/dev-kubernetes-manifests/userservice.yaml
+++ b/dev-kubernetes-manifests/userservice.yaml
@@ -40,7 +40,7 @@ spec:
           containerPort: 8080
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "dev"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/kubernetes-manifests/balance-reader.yaml
+++ b/kubernetes-manifests/balance-reader.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         # toggle Cloud Trace export

--- a/kubernetes-manifests/contacts.yaml
+++ b/kubernetes-manifests/contacts.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/kubernetes-manifests/ledger-writer.yaml
+++ b/kubernetes-manifests/ledger-writer.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/kubernetes-manifests/transaction-history.yaml
+++ b/kubernetes-manifests/transaction-history.yaml
@@ -37,7 +37,7 @@ spec:
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/kubernetes-manifests/userservice.yaml
+++ b/kubernetes-manifests/userservice.yaml
@@ -40,7 +40,7 @@ spec:
           containerPort: 8080
         env:
         - name: VERSION
-          value: "v0.5.3"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/release/make-release.sh
+++ b/release/make-release.sh
@@ -50,6 +50,7 @@ cp -a "${REPO_ROOT}/dev-kubernetes-manifests/." "${REPO_ROOT}/kubernetes-manifes
 
 # update version in manifests
 find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s'image: \(.*\)'image: ${REPO_PREFIX}\/\1:${NEW_VERSION}'g" {} \;
+find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s'value: \"dev\"'value: \"${NEW_VERSION}\"'g" {} \;
 
 # remove the region tags so that there are no duplicates 
 find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e  "s/dev_kubernetes_manifests/boa_kubernetes_manifests/g" {} \;


### PR DESCRIPTION
Previously, the version env was substituted manually in k8s manifests. This change makes sure that we don't miss this step by automating it. Additionally, the dev manifests now has its version statically pinned to `"dev"`.