### PR TITLE
Added functionality to set location values and change metadata server

### DIFF
--- a/dev-kubernetes-manifests/frontend.yaml
+++ b/dev-kubernetes-manifests/frontend.yaml
@@ -53,6 +53,9 @@ spec:
         # Customize the bank name used in the header. Defaults to 'Bank of Anthos' - when CYMBAL_LOGO is true, uses 'CymbalBank'
         # - name: BANK_NAME
         #   value: ""
+        # Customize the cluster name if it cannot be retrieved from the metadata server
+        #- name: CLUSTER_NAME
+        #  value: "my-cluster"
         - name: DEFAULT_USERNAME
           valueFrom:
             configMapKeyRef:
@@ -63,6 +66,12 @@ spec:
             configMapKeyRef:
               name: demo-data-config
               key: DEMO_LOGIN_PASSWORD
+        # Customize the metadata server hostname to query for metadata
+        #- name: METADATA_SERVER
+        #  value: "my-metadata-server"
+        # Customize the pod zone if it cannot be retrieved from the metadata server
+        #- name: POD_ZONE
+        #  value: "my-zone"
         envFrom:
         - configMapRef:
             name: environment-config

--- a/extras/cloudsql/kubernetes-manifests/frontend.yaml
+++ b/extras/cloudsql/kubernetes-manifests/frontend.yaml
@@ -53,6 +53,9 @@ spec:
         # Customize the bank name used in the header. Defaults to 'Bank of Anthos' - when CYMBAL_LOGO is true, uses 'CymbalBank'
         # - name: BANK_NAME
         #   value: ""
+        # Customize the cluster name if it cannot be retrieved from the metadata server
+        #- name: CLUSTER_NAME
+        #  value: "my-cluster"
         - name: DEFAULT_USERNAME
           valueFrom:
             configMapKeyRef:
@@ -68,6 +71,12 @@ spec:
             name: environment-config
         - configMapRef:
             name: service-api-config
+        # Customize the metadata server hostname to query for metadata
+        #- name: METADATA_SERVER
+        #  value: "my-metadata-server"
+        # Customize the pod zone if it cannot be retrieved from the metadata server
+        #- name: POD_ZONE
+        #  value: "my-zone"
         readinessProbe:
           httpGet:
             path: /ready

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -53,6 +53,9 @@ spec:
         # Customize the bank name used in the header. Defaults to 'Bank of Anthos' - when CYMBAL_LOGO is true, uses 'CymbalBank'
         # - name: BANK_NAME
         #   value: ""
+        # Customize the cluster name if it cannot be retrieved from the metadata server
+        #- name: CLUSTER_NAME
+        #  value: "my-cluster"
         - name: DEFAULT_USERNAME
           valueFrom:
             configMapKeyRef:
@@ -63,6 +66,12 @@ spec:
             configMapKeyRef:
               name: demo-data-config
               key: DEMO_LOGIN_PASSWORD
+        # Customize the metadata server hostname to query for metadata
+        #- name: METADATA_SERVER
+        #  value: "my-metadata-server"
+        # Customize the pod zone if it cannot be retrieved from the metadata server
+        #- name: POD_ZONE
+        #  value: "my-zone"
         envFrom:
         - configMapRef:
             name: environment-config

--- a/src/frontend/frontend.py
+++ b/src/frontend/frontend.py
@@ -521,31 +521,33 @@ def create_app():
     app.config['SCHEME'] = os.environ.get('SCHEME', 'http')
 
     # where am I?
-    metadata_url = 'http://metadata.google.internal/computeMetadata/v1/'
+    metadata_server = os.getenv('METADATA_SERVER', 'metadata.google.internal')
+    metadata_url = f'http://{metadata_server}/computeMetadata/v1/'
     metadata_headers = {'Metadata-Flavor': 'Google'}
+
     # get GKE cluster name
-    cluster_name = "unknown"
+    cluster_name = os.getenv('CLUSTER_NAME', 'unknown')
     try:
         req = requests.get(metadata_url + 'instance/attributes/cluster-name',
                            headers=metadata_headers)
         if req.ok:
             cluster_name = str(req.text)
     except (RequestException, HTTPError) as err:
-        app.logger.warning("Unable to capture GKE cluster name.")
+        app.logger.warning(f"Unable to retrieve cluster name from metadata server {metadata_server}.")
 
     # get GKE pod name
     pod_name = "unknown"
     pod_name = socket.gethostname()
 
     # get GKE node zone
-    pod_zone = "unknown"
+    pod_zone = os.getenv('POD_ZONE', 'unknown')
     try:
         req = requests.get(metadata_url + 'instance/zone',
                            headers=metadata_headers)
         if req.ok:
             pod_zone = str(req.text.split("/")[3])
     except (RequestException, HTTPError) as err:
-        app.logger.warning("Unable to capture GKE node zone.")
+        app.logger.warning(f"Unable to retrieve zone from metadata server {metadata_server}.")
 
     # register formater functions
     app.jinja_env.globals.update(format_currency=format_currency)

--- a/src/frontend/frontend.py
+++ b/src/frontend/frontend.py
@@ -533,7 +533,8 @@ def create_app():
         if req.ok:
             cluster_name = str(req.text)
     except (RequestException, HTTPError) as err:
-        app.logger.warning(f"Unable to retrieve cluster name from metadata server {metadata_server}.")
+        app.logger.warning(
+            f"Unable to retrieve cluster name from metadata server {metadata_server}.")
 
     # get GKE pod name
     pod_name = "unknown"


### PR DESCRIPTION
### Background 
The `frontend` service depends on the metadata server to pull the cluster name and zone. The metadata server is not available to all flavors of Anthos.

### Change Summary
Add the ability to change the metadata server to easily point to a simulator or set the values manually via environment variables.

### Testing Procedure
Tested locally by setting the various permutation of the values in the manifest files. Left commented values in manifest files.