### PR TITLE
Update Cloud SQL flavor to 0.5.4 and gce-proxy to 1.30.0

### DIFF
--- a/extras/cloudsql/README.md
+++ b/extras/cloudsql/README.md
@@ -29,10 +29,10 @@ export NAMESPACE="default"
 3. **Create a GKE cluster** with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#overview) enabled. Workload Identity lets you use a Kubernetes service account like a Google Cloud service account, giving your pods granular Google Cloud API permissions - in this case, permission for the Bank of Anthos Pods to access Cloud SQL.
 
 ```
-gcloud container clusters create ${CLUSTER} \
-	--project=${PROJECT_ID} --zone=${ZONE} \
+gcloud container clusters create $CLUSTER \
+	--project=$PROJECT_ID --zone=$ZONE \
 	--machine-type=e2-standard-4 --num-nodes=4 \
-	--workload-pool="${PROJECT_ID}.svc.id.goog"
+	--workload-pool="$PROJECT_ID.svc.id.goog"
 ```
 
 4. **Run the Workload Identity setup script** for your new cluster. This script creates a Google Service Account (GSA) and Kubernetes Service Account (KSA), associates them together, then grants the service account permission to access Cloud SQL.
@@ -50,12 +50,12 @@ gcloud container clusters create ${CLUSTER} \
 6. **Create a Cloud SQL admin demo secret** in your GKE cluster. This gives your in-cluster Cloud SQL client a username and password to access Cloud SQL. (Note that admin/admin credentials are for demo use only and should never be used in a production environment.)
 
 ```
-INSTANCE_NAME='bank-of-anthos-db'
-INSTANCE_CONNECTION_NAME=$(gcloud sql instances describe $INSTANCE_NAME --format='value(connectionName)')
+export INSTANCE_NAME='bank-of-anthos-db'
+export INSTANCE_CONNECTION_NAME=$(gcloud sql instances describe $INSTANCE_NAME --format='value(connectionName)')
 
-kubectl create secret -n ${NAMESPACE} generic cloud-sql-admin \
+kubectl create secret -n $NAMESPACE generic cloud-sql-admin \
  --from-literal=username=admin --from-literal=password=admin \
- --from-literal=connectionName=${INSTANCE_CONNECTION_NAME}
+ --from-literal=connectionName=$INSTANCE_CONNECTION_NAME
 ```
 
 7. **Deploy Bank of Anthos** to your cluster. Each backend Deployment (`userservice`, `contacts`, `transactionhistory`, `balancereader`, and `ledgerwriter`) is configured with a [Cloud SQL Proxy](https://cloud.google.com/sql/docs/mysql/sql-proxy#what_the_proxy_provides) sidecar container. Cloud SQL Proxy provides a secure TLS connection between the backend GKE pods and your Cloud SQL instance.
@@ -63,8 +63,8 @@ kubectl create secret -n ${NAMESPACE} generic cloud-sql-admin \
 This command will also deploy two Kubernetes Jobs, to populate the accounts and ledger dbs with Tables and test data.
 
 ```
-kubectl apply -n ${NAMESPACE} -f ./populate-jobs
-kubectl apply -n ${NAMESPACE} -f ./kubernetes-manifests
+kubectl apply -n $NAMESPACE -f ./populate-jobs
+kubectl apply -n $NAMESPACE -f ./kubernetes-manifests
 ```
 
 8. Wait a few minutes for all the pods to be `RUNNING`. (Except for the two `populate-` Jobs. They should be marked `0/3 - Completed` when they finish successfully.)

--- a/extras/cloudsql/kubernetes-manifests/balance-reader.yaml
+++ b/extras/cloudsql/kubernetes-manifests/balance-reader.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.4
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         # toggle Cloud Trace export
@@ -92,7 +92,7 @@ spec:
           limits:
             cpu: "200m"
             memory: "100Mi"
-        image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-alpine
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
         env:
         - name: CONNECTION_NAME
           valueFrom:

--- a/extras/cloudsql/kubernetes-manifests/contacts.yaml
+++ b/extras/cloudsql/kubernetes-manifests/contacts.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.4
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -70,7 +70,7 @@ spec:
           limits:
             cpu: "200m"
             memory: "100Mi"
-        image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-alpine
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
         env:
         - name: CONNECTION_NAME
           valueFrom:

--- a/extras/cloudsql/kubernetes-manifests/frontend.yaml
+++ b/extras/cloudsql/kubernetes-manifests/frontend.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.4
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/kubernetes-manifests/ledger-writer.yaml
+++ b/extras/cloudsql/kubernetes-manifests/ledger-writer.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.4
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -81,7 +81,7 @@ spec:
           limits:
             cpu: "200m"
             memory: "100Mi"
-        image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-alpine
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
         env:
         - name: CONNECTION_NAME
           valueFrom:

--- a/extras/cloudsql/kubernetes-manifests/loadgenerator.yaml
+++ b/extras/cloudsql/kubernetes-manifests/loadgenerator.yaml
@@ -34,7 +34,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.4
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/extras/cloudsql/kubernetes-manifests/transaction-history.yaml
+++ b/extras/cloudsql/kubernetes-manifests/transaction-history.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.4
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -97,7 +97,7 @@ spec:
           limits:
             cpu: "200m"
             memory: "100Mi"
-        image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-alpine
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
         env:
         - name: CONNECTION_NAME
           valueFrom:

--- a/extras/cloudsql/kubernetes-manifests/userservice.yaml
+++ b/extras/cloudsql/kubernetes-manifests/userservice.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.1
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.4
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"
@@ -40,7 +40,7 @@ spec:
           containerPort: 8080
         env:
         - name: VERSION
-          value: "v0.5.1"
+          value: "v0.5.4"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
@@ -76,7 +76,7 @@ spec:
           limits:
             cpu: "200m"
             memory: "100Mi"
-        image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-alpine
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
         env:
         - name: CONNECTION_NAME
           valueFrom:

--- a/extras/cloudsql/populate-jobs/populate-accounts-db.yaml
+++ b/extras/cloudsql/populate-jobs/populate-accounts-db.yaml
@@ -84,7 +84,7 @@ spec:
           limits:
             cpu: "200m"
             memory: "100Mi"
-        image: gcr.io/cloudsql-docker/gce-proxy:1.19.0-alpine
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
         env:
         - name: CONNECTION_NAME
           valueFrom:

--- a/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
+++ b/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
@@ -84,7 +84,7 @@ spec:
           limits:
             cpu: "200m"
             memory: "100Mi"
-        image: gcr.io/cloudsql-docker/gce-proxy:1.19.0-alpine
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
         env:
         - name: CONNECTION_NAME
           valueFrom:


### PR DESCRIPTION
This PR brings the Cloud SQL flavor up-to-date with v0.5.4, as well as bumps the gce-proxy to 1.30.0

Tested by following the [README instructions](https://github.com/GoogleCloudPlatform/bank-of-anthos/blob/main/extras/cloudsql/README.md):
```
~ k get deployments
NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
balancereader        1/1     1            1           89m
contacts             1/1     1            1           89m
frontend             1/1     1            1           89m
ledgerwriter         1/1     1            1           89m
loadgenerator        1/1     1            1           89m
transactionhistory   1/1     1            1           89m
userservice          1/1     1            1           89m
```

I could deposit funds and transfer funds, which utilizes both databases:

![image](https://user-images.githubusercontent.com/3271352/164762518-ec1bfa65-3575-483b-97b4-8a498d0a3895.png)
