### PR TITLE
Fixed quotes around favicon

### DIFF
--- a/src/frontend/templates/index.html
+++ b/src/frontend/templates/index.html
@@ -24,7 +24,7 @@ limitations under the License.
       {% else %}
       <title>{{ bank_name }}</title>
       {% endif %}
-      <link rel="icon" href=”static/img/favicon.png”/>
+      <link rel="icon" href="static/img/favicon.png"/>
       <link rel="stylesheet" href="https://unpkg.com/bootstrap-material-design@4.1.1/dist/css/bootstrap-material-design.min.css" integrity="sha384-wXznGJNEXNG1NFsbm0ugrLFMQPWswR3lds2VeinahP8N0zJw9VWSopbjv2x7WCvX" crossorigin="anonymous">
       <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
       <link rel="preconnect" href="https://fonts.gstatic.com">

--- a/src/frontend/templates/login.html
+++ b/src/frontend/templates/login.html
@@ -26,7 +26,7 @@ limitations under the License.
       <title>{{ bank_name }}</title>
       {% endif %}
 
-      <link rel="icon" href=”static/img/favicon.png”/>
+      <link rel="icon" href="static/img/favicon.png"/>
       <link rel="stylesheet" href="https://unpkg.com/bootstrap-material-design@4.1.1/dist/css/bootstrap-material-design.min.css" integrity="sha384-wXznGJNEXNG1NFsbm0ugrLFMQPWswR3lds2VeinahP8N0zJw9VWSopbjv2x7WCvX" crossorigin="anonymous">
       <link rel="preconnect" href="https://fonts.gstatic.com">
       <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">

--- a/src/frontend/templates/signup.html
+++ b/src/frontend/templates/signup.html
@@ -24,7 +24,7 @@ limitations under the License.
       {% else %}
       <title>{{ bank_name }}</title>
       {% endif %}
-      <link rel="icon" href=”static/img/favicon.png”/>
+      <link rel="icon" href="static/img/favicon.png"/>
       <link rel="stylesheet" href="https://unpkg.com/bootstrap-material-design@4.1.1/dist/css/bootstrap-material-design.min.css" integrity="sha384-wXznGJNEXNG1NFsbm0ugrLFMQPWswR3lds2VeinahP8N0zJw9VWSopbjv2x7WCvX" crossorigin="anonymous">
       <link rel="preconnect" href="https://fonts.gstatic.com">
       <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
### Background 
The favicon href has right double quotes instead of standard double quotes cause it to throw an error in the browser.

### Change Summary
Changed the quotes

### Testing Procedure
Tested locally

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
