### PR TITLE
Swap default password change manifests

### DIFF
--- a/dev-kubernetes-manifests/config.yaml
+++ b/dev-kubernetes-manifests/config.yaml
@@ -43,6 +43,6 @@ metadata:
 data:
   USE_DEMO_DATA: "True"
   DEMO_LOGIN_USERNAME: "testuser"
-  # All demo user accounts are hardcoded to use the login password 'password'
-  DEMO_LOGIN_PASSWORD: "password"
+  # All demo user accounts are hardcoded to use the login password 'bankofanthos'
+  DEMO_LOGIN_PASSWORD: "bankofanthos"
 # [END gke_dev_kubernetes_manifests_config_configmap_demo_data_config]

--- a/kubernetes-manifests/config.yaml
+++ b/kubernetes-manifests/config.yaml
@@ -43,6 +43,6 @@ metadata:
 data:
   USE_DEMO_DATA: "True"
   DEMO_LOGIN_USERNAME: "testuser"
-  # All demo user accounts are hardcoded to use the login password 'bankofanthos'
-  DEMO_LOGIN_PASSWORD: "bankofanthos"
+  # All demo user accounts are hardcoded to use the login password 'password'
+  DEMO_LOGIN_PASSWORD: "password"
 # [END gke_boa_kubernetes_manifests_config_configmap_demo_data_config]


### PR DESCRIPTION
This PR was merged recently but targeted the `kubernetes-manifests` (which are automatically generated) instead of the `dev-kubernetes-manifests`: https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/759

Since this breaks upstream (the default password change is not "released" yet), this PR is reverting that change (and changing the dev manifests) until a new release of Bank of Anthos is made.