### PR TITLE
Updated the default password to the new value

### DIFF
--- a/dev-kubernetes-manifests/config.yaml
+++ b/dev-kubernetes-manifests/config.yaml
@@ -44,5 +44,5 @@ data:
   USE_DEMO_DATA: "True"
   DEMO_LOGIN_USERNAME: "testuser"
   # All demo user accounts are hardcoded to use the login password 'password'
-  DEMO_LOGIN_PASSWORD: "password"
+  DEMO_LOGIN_PASSWORD: "bankofanthos"
 # [END gke_dev_kubernetes_manifests_config_configmap_demo_data_config]


### PR DESCRIPTION
### Background 
The default password was updated in 2a07277a004f70e42f823da8349c31cac4b03e5c but the dev-kubernetes-manifest was  missed

### Change Summary
Updated to the new default password

### Testing Procedure
Tested locally via skaffold

