### PR TITLE
Bump Java res to match Pod limits and add startupProbes

### DIFF
--- a/dev-kubernetes-manifests/balance-reader.yaml
+++ b/dev-kubernetes-manifests/balance-reader.yaml
@@ -51,7 +51,7 @@ spec:
           value: "1000000"
         # tell Java to obey container memory limits
         - name: JVM_OPTS
-          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms128m -Xmx256m"
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms256m -Xmx512m"
         # Valid levels are debug, info, warn, error, fatal.
         # If no valid level is set, will default to info.
         - name: LOG_LEVEL

--- a/dev-kubernetes-manifests/balance-reader.yaml
+++ b/dev-kubernetes-manifests/balance-reader.yaml
@@ -71,7 +71,7 @@ spec:
             cpu: 100m
             memory: 256Mi
           limits:
-            cpu: 250m
+            cpu: 500m
             memory: 512Mi
         readinessProbe:
           httpGet:
@@ -87,6 +87,12 @@ spec:
           initialDelaySeconds: 120
           periodSeconds: 5
           timeoutSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          failureThreshold: 30
+          periodSeconds: 10
       volumes:
       - name: publickey
         secret:

--- a/dev-kubernetes-manifests/ledger-writer.yaml
+++ b/dev-kubernetes-manifests/ledger-writer.yaml
@@ -67,7 +67,7 @@ spec:
             cpu: 100m
             memory: 256Mi
           limits:
-            cpu: 250m
+            cpu: 500m
             memory: 512Mi
         readinessProbe:
           httpGet:
@@ -76,6 +76,12 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 5
           timeoutSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          failureThreshold: 30
+          periodSeconds: 10
       volumes:
       - name: publickey
         secret:

--- a/dev-kubernetes-manifests/ledger-writer.yaml
+++ b/dev-kubernetes-manifests/ledger-writer.yaml
@@ -46,7 +46,7 @@ spec:
           value: "true"
          # tell Java to obey container memory limits
         - name: JVM_OPTS
-          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms128m -Xmx256m"
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms256m -Xmx512m"
         # service level override of log level
         - name: LOG_LEVEL
           value: "info"

--- a/dev-kubernetes-manifests/transaction-history.yaml
+++ b/dev-kubernetes-manifests/transaction-history.yaml
@@ -76,7 +76,7 @@ spec:
             cpu: 100m
             memory: 256Mi
           limits:
-            cpu: 250m
+            cpu: 500m
             memory: 512Mi
         readinessProbe:
           httpGet:
@@ -92,6 +92,12 @@ spec:
           initialDelaySeconds: 120
           periodSeconds: 5
           timeoutSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          failureThreshold: 30
+          periodSeconds: 10
       volumes:
       - name: publickey
         secret:

--- a/dev-kubernetes-manifests/transaction-history.yaml
+++ b/dev-kubernetes-manifests/transaction-history.yaml
@@ -54,7 +54,7 @@ spec:
           value: "100"
           # tell Java to obey container memory limits
         - name: JVM_OPTS
-          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms128m -Xmx256m"
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms256m -Xmx512m"
         #- name: EXTRA_LATENCY_MILLIS
         #  value: "5000"
         # Valid levels are debug, info, warn, error, fatal.


### PR DESCRIPTION
This PR bumps the Java services' memory requests and limits to match the Pod memory requests and limits.

Making this change to reduce the cold starts and flaky tests from CI builds, without compromising on the amount of K8s nodes required for Bank of Anthos.