### PR TITLE
Split Skaffold config into services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
                 <plugin>
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START gke_bank_of_anthos_skaffold_config_setup]
-apiVersion: skaffold/v2beta18
+apiVersion: skaffold/v2beta28
 kind: Config
 metadata:
   name: setup # module defining setup steps
@@ -25,83 +25,46 @@ deploy:
 # [END gke_bank_of_anthos_skaffold_config_setup]
 ---
 # [START gke_bank_of_anthos_skaffold_config_db]
-apiVersion: skaffold/v2beta18
+apiVersion: skaffold/v2beta28
 kind: Config
 metadata:
-  name: db # module defining database deployments
+  name: contacts-services # module defining contact services
 requires:
   - configs: [setup]
-build:
-  artifacts:
-  - image: accounts-db
-    context: src/accounts-db
-  - image: ledger-db
-    context: src/ledger-db
-deploy:
-  kubectl:
-    manifests:
-    - dev-kubernetes-manifests/accounts-db.yaml
-    - dev-kubernetes-manifests/ledger-db.yaml
+  - path: src/contacts
+  - path: src/userservice
+  - path: src/accounts-db
 # [END gke_bank_of_anthos_skaffold_config_db]
 ---
 # [START gke_bank_of_anthos_skaffold_config_backend]
-apiVersion: skaffold/v2beta18
+apiVersion: skaffold/v2beta28
 kind: Config
 metadata:
-  name: backend # module defining backend services
+  name: ledger-services # module defining ledger services
 requires:
   - configs: [db]
-build:
-  artifacts:
-  - image: ledgerwriter
-    jib:
-      project: src/ledgerwriter
-  - image: balancereader
-    jib:
-      project: src/balancereader
-  - image: transactionhistory
-    jib:
-      project: src/transactionhistory
-  - image: contacts
-    context: src/contacts
-  - image: userservice
-    context: src/userservice
-deploy:
-  kubectl:
-    manifests:
-    - dev-kubernetes-manifests/balance-reader.yaml
-    - dev-kubernetes-manifests/contacts.yaml
-    - dev-kubernetes-manifests/ledger-writer.yaml
-    - dev-kubernetes-manifests/transaction-history.yaml
-    - dev-kubernetes-manifests/userservice.yaml
+  - path: src/ledgerwriter
+  - path: src/balancereader
+  - path: src/transactionhistory
+  - path: src/ledger-db
 # [END gke_bank_of_anthos_skaffold_config_backend]
 ---
 # [START gke_bank_of_anthos_skaffold_config_frontend]
-apiVersion: skaffold/v2beta18
+apiVersion: skaffold/v2beta28
 kind: Config
 metadata:
-  name: frontend # module defining frontend service
-build:
-  artifacts:
-  - image: frontend
-    context: src/frontend
-deploy:
-  kubectl:
-    manifests:
-    - dev-kubernetes-manifests/frontend.yaml
+  name: frontend-services # module defining frontend service
+requires:
+  - configs: [setup]
+  - path: src/frontend
 # [END gke_bank_of_anthos_skaffold_config_frontend]
 ---
 # [START gke_bank_of_anthos_skaffold_config_loadgenerator]
-apiVersion: skaffold/v2beta18
+apiVersion: skaffold/v2beta28
 kind: Config
 metadata:
-  name: loadgenerator # module defining a load generator service
-build:
-  artifacts:
-  - image: loadgenerator
-    context: src/loadgenerator
-deploy:
-  kubectl:
-    manifests:
-    - dev-kubernetes-manifests/loadgenerator.yaml
+  name: loadgenerator-services # module defining a load generator service
+requires:
+  - configs: [frontend]
+  - path: src/loadgenerator
 # [END gke_bank_of_anthos_skaffold_config_loadgenerator]

--- a/src/accounts-db/skaffold.yaml
+++ b/src/accounts-db/skaffold.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_bank_of_anthos_skaffold_config_accounts_db]
+apiVersion: skaffold/v2beta28
+kind: Config
+metadata:
+  name: accounts-db
+build:
+  artifacts:
+  - image: accounts-db
+    context: ./
+deploy:
+  kubectl:
+    manifests:
+    - ../../dev-kubernetes-manifests/accounts-db.yaml
+# [END gke_bank_of_anthos_skaffold_config_accounts_db]

--- a/src/balancereader/skaffold.yaml
+++ b/src/balancereader/skaffold.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_bank_of_anthos_skaffold_config_balancereader]
+apiVersion: skaffold/v2beta28
+kind: Config
+metadata:
+  name: balancereader
+build:
+  artifacts:
+  - image: balancereader
+    jib:
+      project: ../
+deploy:
+  kubectl:
+    manifests:
+    - ../../dev-kubernetes-manifests/balance-reader.yaml
+# [END gke_bank_of_anthos_skaffold_config_balancereader]

--- a/src/contacts/skaffold.yaml
+++ b/src/contacts/skaffold.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_bank_of_anthos_skaffold_config_contacts]
+apiVersion: skaffold/v2beta28
+kind: Config
+metadata:
+  name: contacts
+build:
+  artifacts:
+  - image: contacts
+    context: ./
+deploy:
+  kubectl:
+    manifests:
+    - ../../dev-kubernetes-manifests/contacts.yaml
+# [END gke_bank_of_anthos_skaffold_config_contacts]

--- a/src/frontend/skaffold.yaml
+++ b/src/frontend/skaffold.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_bank_of_anthos_skaffold_config_frontend]
+apiVersion: skaffold/v2beta28
+kind: Config
+metadata:
+  name: frontend
+build:
+  artifacts:
+  - image: frontend
+    context: ./
+deploy:
+  kubectl:
+    manifests:
+    - ../../dev-kubernetes-manifests/frontend.yaml
+# [END gke_bank_of_anthos_skaffold_config_frontend]

--- a/src/ledger-db/skaffold.yaml
+++ b/src/ledger-db/skaffold.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_bank_of_anthos_skaffold_config_ledger_db]
+apiVersion: skaffold/v2beta28
+kind: Config
+metadata:
+  name: ledger-db
+build:
+  artifacts:
+  - image: ledger-db
+    context: ./
+deploy:
+  kubectl:
+    manifests:
+    - ../../dev-kubernetes-manifests/ledger-db.yaml
+# [END gke_bank_of_anthos_skaffold_config_ledger_db]

--- a/src/ledgerwriter/skaffold.yaml
+++ b/src/ledgerwriter/skaffold.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_bank_of_anthos_skaffold_config_ledgerwriter]
+apiVersion: skaffold/v2beta28
+kind: Config
+metadata:
+  name: ledgerwriter
+build:
+  artifacts:
+  - image: ledgerwriter
+    jib:
+      project: ./
+deploy:
+  kubectl:
+    manifests:
+    - ../../dev-kubernetes-manifests/ledger-writer.yaml
+# [END gke_bank_of_anthos_skaffold_config_ledgerwriter]

--- a/src/loadgenerator/skaffold.yaml
+++ b/src/loadgenerator/skaffold.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_bank_of_anthos_skaffold_config_loadgenerator]
+apiVersion: skaffold/v2beta18
+kind: Config
+metadata:
+  name: loadgenerator
+build:
+  artifacts:
+  - image: loadgenerator
+    context: ./
+deploy:
+  kubectl:
+    manifests:
+    - ../../dev-kubernetes-manifests/loadgenerator.yaml
+# [END gke_bank_of_anthos_skaffold_config_loadgenerator]

--- a/src/transactionhistory/skaffold.yaml
+++ b/src/transactionhistory/skaffold.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_bank_of_anthos_skaffold_config_transactionhistory]
+apiVersion: skaffold/v2beta28
+kind: Config
+metadata:
+  name: transactionhistory
+build:
+  artifacts:
+  - image: transactionhistory
+    jib:
+      project: ./
+deploy:
+  kubectl:
+    manifests:
+    - ../../dev-kubernetes-manifests/transaction-history.yaml
+# [END gke_bank_of_anthos_skaffold_config_transactionhistory]

--- a/src/userservice/skaffold.yaml
+++ b/src/userservice/skaffold.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_bank_of_anthos_skaffold_config_userservice]
+apiVersion: skaffold/v2beta28
+kind: Config
+metadata:
+  name: userservice
+build:
+  artifacts:
+  - image: userservice
+    context: ./
+deploy:
+  kubectl:
+    manifests:
+    - ../../dev-kubernetes-manifests/userservice.yaml
+# [END gke_bank_of_anthos_skaffold_config_userservice]


### PR DESCRIPTION
This PR splits the monolithic Skaffold service into its relevant services [description WIP]

It also moves services around modules [description WIP] to better reflect how hypothetical teams could look like.

![image](https://user-images.githubusercontent.com/3271352/167036899-1d0efb00-978d-4c2f-a5df-688a6905595b.png)

This PR is WIP and still a draft, but opened to comments.