### PR TITLE
Bump CPU for userservice for cypress tests 

### DIFF
--- a/.github/workflows/ui-tests/cypress/integration/create_spec.js
+++ b/.github/workflows/ui-tests/cypress/integration/create_spec.js
@@ -74,7 +74,7 @@ describe('Signup is unsuccessful with non-alphanumeric username', function() {
 
 
 describe('User can create account', function() {
-    const uuid = () => Cypress._.random(0, 1e6)
+    const uuid = () => Cypress._.random(0, 1e7)
     const password = 'bells'
     const firstName = 'Tom'
     const lastName = 'Nook'
@@ -85,7 +85,7 @@ describe('User can create account', function() {
         const user = {
             username: `user_${id}`,
             firstName: firstName,
-            lastName: `${lastName}-${id}`,
+            lastName: lastName,
             password: password
         }
 

--- a/.github/workflows/ui-tests/cypress/integration/create_spec.js
+++ b/.github/workflows/ui-tests/cypress/integration/create_spec.js
@@ -97,14 +97,17 @@ describe('User can create account', function() {
     })
 
     it('contain zero balance', function() {
+        cy.wait(500)
         cy.get('#current-balance').contains(expectedBalance)
     })
 
     it('sees correct username', function() {
+        cy.wait(500)
         cy.get('#accountDropdown').contains(`${firstName} ${lastName}`)
     })
 
     it('sees empty transaction history message', function() {
+        cy.wait(500)
         const transactionMsgs = Cypress.env('messages').transaction
         // sees empty transaction history message
         cy.get('#transaction-table').children('.card-table-header').contains(transactionMsgs.empty)
@@ -115,6 +118,7 @@ describe('User can create account', function() {
 
 
     it('sees no transactions', function() {
+        cy.wait(500)
         // new accounts only see empty history message
         // new accounts should not see a table
         cy.get('#transaction-table').children().should('have.length', 1)

--- a/.github/workflows/ui-tests/cypress/integration/create_spec.js
+++ b/.github/workflows/ui-tests/cypress/integration/create_spec.js
@@ -74,7 +74,7 @@ describe('Signup is unsuccessful with non-alphanumeric username', function() {
 
 
 describe('User can create account', function() {
-    const uuid = () => Cypress._.random(0, 1e7)
+    const uuid = () => Cypress._.random(0, 1e6)
     const password = 'bells'
     const firstName = 'Tom'
     const lastName = 'Nook'
@@ -85,7 +85,7 @@ describe('User can create account', function() {
         const user = {
             username: `user_${id}`,
             firstName: firstName,
-            lastName: lastName,
+            lastName: `${lastName}-${id}`,
             password: password
         }
 
@@ -97,17 +97,14 @@ describe('User can create account', function() {
     })
 
     it('contain zero balance', function() {
-        cy.wait(500)
         cy.get('#current-balance').contains(expectedBalance)
     })
 
     it('sees correct username', function() {
-        cy.wait(500)
         cy.get('#accountDropdown').contains(`${firstName} ${lastName}`)
     })
 
     it('sees empty transaction history message', function() {
-        cy.wait(500)
         const transactionMsgs = Cypress.env('messages').transaction
         // sees empty transaction history message
         cy.get('#transaction-table').children('.card-table-header').contains(transactionMsgs.empty)
@@ -118,7 +115,6 @@ describe('User can create account', function() {
 
 
     it('sees no transactions', function() {
-        cy.wait(500)
         // new accounts only see empty history message
         // new accounts should not see a table
         cy.get('#transaction-table').children().should('have.length', 1)

--- a/dev-kubernetes-manifests/userservice.yaml
+++ b/dev-kubernetes-manifests/userservice.yaml
@@ -66,10 +66,10 @@ spec:
           timeoutSeconds: 10
         resources:
           requests:
-            cpu: 100m
+            cpu: 200m
             memory: 64Mi
           limits:
-            cpu: 250m
+            cpu: 500m
             memory: 256Mi
       volumes:
       - name: keys


### PR DESCRIPTION
### Fixes n/a

### Background 
I've been noticing some flaky frontend tests. This is causing PRs to fail on CI tests. Even clicking through the front end on URLs takes a while.
Running tests in my own GCP project, it passed (I only ran it 2 times) 
Only noticed failing tests around the create_spec.js, specifically the User can create account suites in the PRs currently

### Change Summary
Added timeouts to the  cypress create tests.

### Additional Notes
We should remove these waits, and do a deeper investigation why.

### Testing Procedure
Hopefully the CI tests pass

### Related PRs or Issues 
n/a
