### PR TITLE
Bump log4j to 2.18.0

### DIFF
--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -108,12 +108,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -97,12 +97,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -98,12 +98,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -108,12 +108,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>


### PR DESCRIPTION
This PR bumps log4j to 2.18.0, essentially combining https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/877 and https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/878, since they need to happen at the same time.