### PR TITLE
Prevent gh actions from running on draft pr

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -15,6 +15,7 @@
 name: "Continuous Integration - Pull Request"
 on:
   pull_request:
+    types: [review_requested, ready_for_review]
     branches:
       - main
 jobs:


### PR DESCRIPTION
### Fixes n/a

### Background 
On draft PRs, the gh ci runs. Depending on how long a draft is open for, it could use up resources for us.

### Change Summary
Add a type on `ready to review`, and `requested review in` the ci-pr.yaml

### Additional Notes
https://github.com/GoogleCloudPlatform/microservices-demo/pull/926

### Testing Procedure
Open in draft, tests dont run

### Related PRs or Issues 
n/a
