### PR TITLE
CloudSQL fixes

### DIFF
--- a/extras/cloudsql/README.md
+++ b/extras/cloudsql/README.md
@@ -69,6 +69,7 @@ kubectl create secret -n $NAMESPACE generic cloud-sql-admin \
 This command will also deploy two Kubernetes Jobs, to populate the accounts and ledger dbs with Tables and test data.
 
 ```
+kubectl apply -n $NAMESPACE -f ./kubernetes-manifests/config.yaml
 kubectl apply -n $NAMESPACE -f ./populate-jobs
 kubectl apply -n $NAMESPACE -f ./kubernetes-manifests
 ```

--- a/extras/cloudsql/create_cloudsql_instance.sh
+++ b/extras/cloudsql/create_cloudsql_instance.sh
@@ -24,7 +24,7 @@ CSQL_EXISTS=$(gcloud sql instances list --filter="${INSTANCE_NAME}" | wc -l)
 if [ $CSQL_EXISTS = "0" ]; then
   echo "☁️ Creating Cloud SQL instance: ${INSTANCE_NAME} ..."
   gcloud sql instances create $INSTANCE_NAME \
-    --database-version=POSTGRES_12 --tier=db-custom-1-3840 \
+    --database-version=POSTGRES_14 --tier=db-custom-1-3840 \
     --region=${DB_REGION} --project ${PROJECT_ID}
 fi
 

--- a/extras/cloudsql/kubernetes-manifests/balance-reader.yaml
+++ b/extras/cloudsql/kubernetes-manifests/balance-reader.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.4
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.6
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.4"
+          value: "v0.5.6"
         - name: PORT
           value: "8080"
         # toggle Cloud Trace export

--- a/extras/cloudsql/kubernetes-manifests/contacts.yaml
+++ b/extras/cloudsql/kubernetes-manifests/contacts.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.4
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.6
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.4"
+          value: "v0.5.6"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/kubernetes-manifests/frontend.yaml
+++ b/extras/cloudsql/kubernetes-manifests/frontend.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.4
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.6
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.4"
+          value: "v0.5.6"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/kubernetes-manifests/ledger-writer.yaml
+++ b/extras/cloudsql/kubernetes-manifests/ledger-writer.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.4
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.6
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.4"
+          value: "v0.5.6"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/kubernetes-manifests/loadgenerator.yaml
+++ b/extras/cloudsql/kubernetes-manifests/loadgenerator.yaml
@@ -34,7 +34,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.4
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.6
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/extras/cloudsql/kubernetes-manifests/transaction-history.yaml
+++ b/extras/cloudsql/kubernetes-manifests/transaction-history.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.4
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.6
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.5.4"
+          value: "v0.5.6"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/kubernetes-manifests/userservice.yaml
+++ b/extras/cloudsql/kubernetes-manifests/userservice.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.4
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.6
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"
@@ -40,7 +40,7 @@ spec:
           containerPort: 8080
         env:
         - name: VERSION
-          value: "v0.5.4"
+          value: "v0.5.6"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/extras/cloudsql/populate-jobs/populate-accounts-db.yaml
+++ b/extras/cloudsql/populate-jobs/populate-accounts-db.yaml
@@ -35,7 +35,7 @@ spec:
             cpu: "200m"
             memory: "100Mi"
       - name: populate-accounts-db
-        image: postgres:13.0
+        image: postgres:14-alpine
         command: ['bash', '-c','. /scripts/initialize-database.sh 127.0.0.1 5432 accounts-db']
         volumeMounts:
         - name: scripts

--- a/extras/cloudsql/populate-jobs/populate-accounts-db.yaml
+++ b/extras/cloudsql/populate-jobs/populate-accounts-db.yaml
@@ -12,97 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_populate_jobs_populate_accounts_db_job_populate_accounts_db]
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: populate-accounts-db
-spec:
-  template:
-    spec:
-      shareProcessNamespace: true # Important to stop all processes
-      serviceAccountName: boa-ksa
-      containers:
-      - name: sidecar-controller
-        image: bash
-        command: ['bash', '-c', '. /scripts/wait-to-complete-sidecar.sh "initialize-database.sh" "cloud_sql_proxy"']
-        volumeMounts:
-        - name: scripts
-          mountPath: "/scripts"
-          readOnly: true
-        resources:
-          limits:
-            cpu: "200m"
-            memory: "100Mi"
-      - name: populate-accounts-db
-        image: postgres:14-alpine
-        command: ['bash', '-c','. /scripts/initialize-database.sh 127.0.0.1 5432 accounts-db']
-        volumeMounts:
-        - name: scripts
-          mountPath: "/scripts"
-          readOnly: true
-        env:
-        - name: PGUSER
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: username
-        - name: PGPASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: password
-        # /start: Required for testing data
-        - name: LOCAL_ROUTING_NUM
-          valueFrom:
-            configMapKeyRef:
-              name: environment-config
-              key: LOCAL_ROUTING_NUM
-        - name: USE_DEMO_DATA
-          valueFrom:
-            configMapKeyRef:
-              name: demo-data-config
-              key: USE_DEMO_DATA
-        - name: POSTGRES_DB
-          value: "accounts-db"
-        - name: PGHOSTADDR
-          value: "127.0.0.1"
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: username
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: password
-      # /end: Required for testing data
-      # CloudSQL Proxy
-      - name: cloudsql-proxy
-        resources:
-          limits:
-            cpu: "200m"
-            memory: "100Mi"
-        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
-        env:
-        - name: CONNECTION_NAME
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: connectionName
-        command: ["/cloud_sql_proxy",
-                  "-instances=$(CONNECTION_NAME)=tcp:5432"]
-        securityContext:
-          runAsNonRoot: true
-      volumes:
-      - name: scripts
-        configMap:
-          name: accounts-schema-config
-      restartPolicy: Never
-  backoffLimit: 4
-# [END gke_populate_jobs_populate_accounts_db_job_populate_accounts_db]
----
 # [START gke_populate_jobs_populate_accounts_db_configmap_accounts_schema_config]
 # kubectl create configmap accounts-schema-config --from-file=src/accounts-db/initdb/0-accounts-schema.sql --dry-run -o yaml (copy and add below)
 # kubectl create configmap accounts-schema-config --from-file=src/accounts-db/initdb/1-load-testdata.sh --dry-run -o yaml (copy and add below)
@@ -339,3 +248,94 @@ data:
     main
 
 # [END gke_populate_jobs_populate_accounts_db_configmap_accounts_schema_config]
+---
+# [START gke_populate_jobs_populate_accounts_db_job_populate_accounts_db]
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: populate-accounts-db
+spec:
+  template:
+    spec:
+      shareProcessNamespace: true # Important to stop all processes
+      serviceAccountName: boa-ksa
+      containers:
+      - name: sidecar-controller
+        image: bash
+        command: ['bash', '-c', '. /scripts/wait-to-complete-sidecar.sh "initialize-database.sh" "cloud_sql_proxy"']
+        volumeMounts:
+        - name: scripts
+          mountPath: "/scripts"
+          readOnly: true
+        resources:
+          limits:
+            cpu: "200m"
+            memory: "100Mi"
+      - name: populate-accounts-db
+        image: postgres:14-alpine
+        command: ['bash', '-c','. /scripts/initialize-database.sh 127.0.0.1 5432 accounts-db']
+        volumeMounts:
+        - name: scripts
+          mountPath: "/scripts"
+          readOnly: true
+        env:
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: username
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: password
+        # /start: Required for testing data
+        - name: LOCAL_ROUTING_NUM
+          valueFrom:
+            configMapKeyRef:
+              name: environment-config
+              key: LOCAL_ROUTING_NUM
+        - name: USE_DEMO_DATA
+          valueFrom:
+            configMapKeyRef:
+              name: demo-data-config
+              key: USE_DEMO_DATA
+        - name: POSTGRES_DB
+          value: "accounts-db"
+        - name: PGHOSTADDR
+          value: "127.0.0.1"
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: username
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: password
+      # /end: Required for testing data
+      # CloudSQL Proxy
+      - name: cloudsql-proxy
+        resources:
+          limits:
+            cpu: "200m"
+            memory: "100Mi"
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
+        env:
+        - name: CONNECTION_NAME
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: connectionName
+        command: ["/cloud_sql_proxy",
+                  "-instances=$(CONNECTION_NAME)=tcp:5432"]
+        securityContext:
+          runAsNonRoot: true
+      volumes:
+      - name: scripts
+        configMap:
+          name: accounts-schema-config
+      restartPolicy: Never
+  backoffLimit: 4
+# [END gke_populate_jobs_populate_accounts_db_job_populate_accounts_db]

--- a/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
+++ b/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
@@ -327,6 +327,8 @@ spec:
               key: connectionName
         command: ["/cloud_sql_proxy",
                   "-instances=$(CONNECTION_NAME)=tcp:5432"]
+        securityContext:
+          runAsNonRoot: true
       volumes:
       - name: scripts
         configMap:

--- a/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
+++ b/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
@@ -12,95 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_populate_jobs_populate_ledger_db_job_populate_ledger_db]
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: populate-ledger-db
-spec:
-  template:
-    spec:
-      shareProcessNamespace: true # Important to stop all processes
-      serviceAccountName: boa-ksa
-      containers:
-      - name: sidecar-controller
-        image: bash
-        command: ['bash', '-c', '. /scripts/wait-to-complete-sidecar.sh "initialize-database.sh" "cloud_sql_proxy"']
-        volumeMounts:
-        - name: scripts
-          mountPath: "/scripts"
-          readOnly: true
-        resources:
-          limits:
-            cpu: "200m"
-            memory: "100Mi"
-      - name: populate-ledger-db
-        image: postgres:14-alpine
-        command: ['bash', '-c','. /scripts/initialize-database.sh 127.0.0.1 5432 ledger-db']
-        volumeMounts:
-        - name: scripts
-          mountPath: "/scripts"
-          readOnly: true
-        env:
-        - name: PGUSER
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: username
-        - name: PGPASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: password
-        # /start: Required for testing data
-        - name: LOCAL_ROUTING_NUM
-          valueFrom:
-            configMapKeyRef:
-              name: environment-config
-              key: LOCAL_ROUTING_NUM
-        - name: USE_DEMO_DATA
-          valueFrom:
-            configMapKeyRef:
-              name: demo-data-config
-              key: USE_DEMO_DATA
-        - name: POSTGRES_DB
-          value: "ledger-db"
-        - name: PGHOSTADDR
-          value: "127.0.0.1"
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: username
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: password
-      # /end: Required for testing data
-      # CloudSQL Proxy
-      - name: cloudsql-proxy
-        resources:
-          limits:
-            cpu: "200m"
-            memory: "100Mi"
-        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
-        env:
-        - name: CONNECTION_NAME
-          valueFrom:
-            secretKeyRef:
-              name: cloud-sql-admin
-              key: connectionName
-        command: ["/cloud_sql_proxy",
-                  "-instances=$(CONNECTION_NAME)=tcp:5432"]
-      volumes:
-      - name: scripts
-        configMap:
-          name: ledger-schema-config
-      restartPolicy: Never
-  backoffLimit: 4
-# [END gke_populate_jobs_populate_ledger_db_job_populate_ledger_db]
----
 # [START gke_populate_jobs_populate_ledger_db_configmap_ledger_schema_config]
 # kubectl create configmap ledger-schema-config --from-file=src/ledger-db/initdb/0-ledger-schema.sql --dry-run -o yaml (copy and add below)
 # kubectl create configmap ledger-schema-config --from-file=src/ledger-db/initdb/1-load-testdata.sh --dry-run -o yaml (copy and add below)
@@ -334,3 +245,92 @@ data:
     main
 
 # [END gke_populate_jobs_populate_ledger_db_configmap_ledger_schema_config]
+---
+# [START gke_populate_jobs_populate_ledger_db_job_populate_ledger_db]
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: populate-ledger-db
+spec:
+  template:
+    spec:
+      shareProcessNamespace: true # Important to stop all processes
+      serviceAccountName: boa-ksa
+      containers:
+      - name: sidecar-controller
+        image: bash
+        command: ['bash', '-c', '. /scripts/wait-to-complete-sidecar.sh "initialize-database.sh" "cloud_sql_proxy"']
+        volumeMounts:
+        - name: scripts
+          mountPath: "/scripts"
+          readOnly: true
+        resources:
+          limits:
+            cpu: "200m"
+            memory: "100Mi"
+      - name: populate-ledger-db
+        image: postgres:14-alpine
+        command: ['bash', '-c','. /scripts/initialize-database.sh 127.0.0.1 5432 ledger-db']
+        volumeMounts:
+        - name: scripts
+          mountPath: "/scripts"
+          readOnly: true
+        env:
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: username
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: password
+        # /start: Required for testing data
+        - name: LOCAL_ROUTING_NUM
+          valueFrom:
+            configMapKeyRef:
+              name: environment-config
+              key: LOCAL_ROUTING_NUM
+        - name: USE_DEMO_DATA
+          valueFrom:
+            configMapKeyRef:
+              name: demo-data-config
+              key: USE_DEMO_DATA
+        - name: POSTGRES_DB
+          value: "ledger-db"
+        - name: PGHOSTADDR
+          value: "127.0.0.1"
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: username
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: password
+      # /end: Required for testing data
+      # CloudSQL Proxy
+      - name: cloudsql-proxy
+        resources:
+          limits:
+            cpu: "200m"
+            memory: "100Mi"
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.0
+        env:
+        - name: CONNECTION_NAME
+          valueFrom:
+            secretKeyRef:
+              name: cloud-sql-admin
+              key: connectionName
+        command: ["/cloud_sql_proxy",
+                  "-instances=$(CONNECTION_NAME)=tcp:5432"]
+      volumes:
+      - name: scripts
+        configMap:
+          name: ledger-schema-config
+      restartPolicy: Never
+  backoffLimit: 4
+# [END gke_populate_jobs_populate_ledger_db_job_populate_ledger_db]

--- a/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
+++ b/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
@@ -170,7 +170,7 @@ data:
 
 
     add_transaction() {
-        DATE=$(date -u +"%Y-%m-%d %H:%M:%S.%3N%z" --date="@$(($6))")
+        DATE=$(date -u +"%Y-%m-%d %H:%M:%S%z" --date="@$(($6))")
         echo "adding demo transaction: $1 -> $2"
         psql -X -v ON_ERROR_STOP=1 -v fromacct="$1" -v toacct="$2" -v fromroute="$3" -v toroute="$4" -v amount="$5" --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
             INSERT INTO TRANSACTIONS (FROM_ACCT, TO_ACCT, FROM_ROUTE, TO_ROUTE, AMOUNT, TIMESTAMP)

--- a/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
+++ b/extras/cloudsql/populate-jobs/populate-ledger-db.yaml
@@ -35,7 +35,7 @@ spec:
             cpu: "200m"
             memory: "100Mi"
       - name: populate-ledger-db
-        image: postgres:13.0
+        image: postgres:14-alpine
         command: ['bash', '-c','. /scripts/initialize-database.sh 127.0.0.1 5432 ledger-db']
         volumeMounts:
         - name: scripts


### PR DESCRIPTION
### Background 
While trying to deploy the Bank of Anthos application using CloudSQL I encountered several issues with the populate jobs not completing. It was determined that this was due to the populate jobs having a dependency on the config.yaml manifest

### Change Summary
- Updated to PostgreSQL 14 to match the in-cluster database
- Moved the ConfigMaps for the populate jobs to be before the Job itself.
- Added an apply of the config.yaml file before applying the populate jobs
- Added the runAsNonRoot securityContext to populate-ledger-db.yaml.
- Updated to the Bank of Anthos 0.5.6 version
- Fixed an issue with the timestamp format for one of the populate jobs. The default date utility on Alpine does not support
%N as it is a GNU extension.

### Testing Procedure
Tested in a Qwiklab environment using a GKE Standard cluster.