### PR TITLE
Update ledgermonolith config to be in-line with 0.5.6

### DIFF
--- a/src/ledgermonolith/config.yaml
+++ b/src/ledgermonolith/config.yaml
@@ -20,7 +20,7 @@ metadata:
   name: environment-config
 data:
   LOCAL_ROUTING_NUM: "883745000"
-  PUB_KEY_PATH: "/root/.ssh/publickey"
+  PUB_KEY_PATH: "/tmp/.ssh/publickey"
 # [END gke_ledgermonolith_config_configmap_environment_config]
 ---
 # [START gke_ledgermonolith_config_configmap_service_api_config]


### PR DESCRIPTION
Fixed #908 by bringing the ledgermonolith config in-line with 0.5.6 changes (specifically, this change: https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/855)