### PR TITLE
`openjdk:17-slim`

### DIFF
--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -161,7 +161,7 @@
                 <version>3.2.1</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17</image>
+                        <image>openjdk:17-slim</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -163,6 +163,9 @@
                     <from>
                         <image>openjdk:17-slim</image>
                     </from>
+                    <to>
+                        <image>openjdk:17-slim</image>
+                    </to>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -152,6 +152,9 @@
                     <from>
                         <image>openjdk:17-slim</image>
                     </from>
+                    <to>
+                        <image>openjdk:17-slim</image>
+                    </to>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -150,7 +150,7 @@
                 <version>3.2.1</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17</image>
+                        <image>openjdk:17-slim</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -151,8 +151,11 @@
                 <version>3.2.1</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17</image>
+                        <image>openjdk:17-slim</image>
                     </from>
+                    <to>
+                        <image>openjdk:17-slim</image>
+                    </to>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -161,8 +161,11 @@
                 <version>3.2.1</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17</image>
+                        <image>openjdk:17-slim</image>
                     </from>
+                    <to>
+                        <image>openjdk:17-slim</image>
+                    </to>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
`openjdk:17-slim` for `ledgerwriter`, `balancereader`, `transactionhistory` and `ledgermonolith`.

All the Java container images are now in `-slim` like it was already the case for the Python container images.

I also added the `<to>` section (in addition to the `<from>` one already existing) to make sure it's taking the right image, [apparently this field is mandatory](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#to-object).

The images went from the size of 318.2 MB to 296.7 MB.