### PR TITLE
update python 3.10.0 for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "fileMatch": ["(^|/)requirements\\.in$"]
   },
   "constraints": {
-    "python": "~=3.7.0"
+    "python": "~=3.10.0"
   },
   "prConcurrentLimit":5,
   "stabilityDays":7,


### PR DESCRIPTION
With this https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/933, I just saw that Renovate was still configured for Python 3.7, but all the Python apps are now in 3.10.