### PR TITLE
Add missing git add to release script

### DIFF
--- a/release/make-release.sh
+++ b/release/make-release.sh
@@ -61,6 +61,7 @@ find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e  "s/dev_
 # push release PR
 git checkout -b "release/${NEW_VERSION}"
 git add "${REPO_ROOT}/kubernetes-manifests/*.yaml"
+git add "${REPO_ROOT}/iac/tf-anthos-gke/terraform.tfvars"
 git commit -m "release/${NEW_VERSION}"
 
 # add tag


### PR DESCRIPTION
This PR adds a missing line to the release script which I noticed while release 0.5.7 earlier today.

This line is a follow-up of https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/881