### PR TITLE
`openjdk:17-slim` --> `openjdk:17-alpine`

### DIFF
--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -163,9 +163,6 @@
                     <from>
                         <image>openjdk:17-alpine</image>
                     </from>
-                    <to>
-                        <image>openjdk:17-alpine</image>
-                    </to>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -164,7 +164,7 @@
                         <image>openjdk:17-slim</image>
                     </from>
                     <to>
-                        <image>openjdk:17-slim</image>
+                        <image>openjdk:17-alpine</image>
                     </to>
                 </configuration>
             </plugin>

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -161,7 +161,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17-slim</image>
+                        <image>openjdk:17-alpine</image>
                     </from>
                     <to>
                         <image>openjdk:17-alpine</image>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -150,11 +150,8 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17-slim</image>
+                        <image>openjdk:17-alpine</image>
                     </from>
-                    <to>
-                        <image>openjdk:17-slim</image>
-                    </to>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -151,11 +151,8 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17-slim</image>
+                        <image>openjdk:17-alpine</image>
                     </from>
-                    <to>
-                        <image>openjdk:17-slim</image>
-                    </to>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -161,11 +161,8 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17-slim</image>
+                        <image>openjdk:17-alpine</image>
                     </from>
-                    <to>
-                        <image>openjdk:17-slim</image>
-                    </to>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
`openjdk:17-slim` --> `openjdk:17-alpine`

Before: 297.2 MB - 51 vulnerabilities
After: 268.3 MB -  16 vulnerabilities

_Note: also did a cleanup with the `<to>` sections not used at all, only `<from>` counts apparently._