### PR TITLE
Bump opentel to 1.13.0

### DIFF
--- a/src/contacts/requirements.in
+++ b/src/contacts/requirements.in
@@ -21,11 +21,11 @@ itsdangerous==2.1.2
 jinja2==3.1.2
 markupsafe==2.1.1
 more-itertools==8.14.0
-opentelemetry-sdk==1.12.0
+opentelemetry-sdk==1.13.0
 opentelemetry-exporter-gcp-trace==1.3.0
 opentelemetry-propagator-gcp==1.3.0
-opentelemetry-instrumentation-flask==0.33b0
-opentelemetry-instrumentation-sqlalchemy==0.33b0
+opentelemetry-instrumentation-flask==0.34b0
+opentelemetry-instrumentation-sqlalchemy==0.34b0
 packaging==21.3
 pluggy==1.0.0
 protobuf==4.21.6

--- a/src/contacts/requirements.txt
+++ b/src/contacts/requirements.txt
@@ -77,7 +77,9 @@ idna==3.4
     #   -r requirements.in
     #   requests
 importlib-metadata==4.12.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   flask
 iniconfig==1.1.1
     # via pytest
 itsdangerous==2.1.2
@@ -95,7 +97,7 @@ markupsafe==2.1.1
     #   werkzeug
 more-itertools==8.14.0
     # via -r requirements.in
-opentelemetry-api==1.12.0
+opentelemetry-api==1.13.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -106,30 +108,30 @@ opentelemetry-api==1.12.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.3.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.33b0
+opentelemetry-instrumentation==0.34b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.33b0
+opentelemetry-instrumentation-flask==0.34b0
     # via -r requirements.in
-opentelemetry-instrumentation-sqlalchemy==0.33b0
+opentelemetry-instrumentation-sqlalchemy==0.34b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.33b0
+opentelemetry-instrumentation-wsgi==0.34b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.3.0
     # via -r requirements.in
-opentelemetry-sdk==1.12.0
+opentelemetry-sdk==1.13.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
-opentelemetry-semantic-conventions==0.33b0
+opentelemetry-semantic-conventions==0.34b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.33b0
+opentelemetry-util-http==0.34b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-wsgi

--- a/src/frontend/requirements.in
+++ b/src/frontend/requirements.in
@@ -4,9 +4,9 @@ urllib3==1.26.12
 pyjwt==2.5.0
 cryptography==38.0.1
 gunicorn==20.1.0
-opentelemetry-sdk==1.12.0
+opentelemetry-sdk==1.13.0
 opentelemetry-exporter-gcp-trace==1.3.0
 opentelemetry-propagator-gcp==1.3.0
-opentelemetry-instrumentation-flask==0.33b0
-opentelemetry-instrumentation-jinja2==0.33b0
-opentelemetry-instrumentation-requests==0.33b0
+opentelemetry-instrumentation-flask==0.34b0
+opentelemetry-instrumentation-jinja2==0.34b0
+opentelemetry-instrumentation-requests==0.34b0

--- a/src/frontend/requirements.txt
+++ b/src/frontend/requirements.txt
@@ -40,6 +40,8 @@ gunicorn==20.1.0
     # via -r requirements.in
 idna==3.4
     # via requests
+importlib-metadata==4.12.0
+    # via flask
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
@@ -48,7 +50,7 @@ markupsafe==2.1.1
     # via
     #   jinja2
     #   werkzeug
-opentelemetry-api==1.12.0
+opentelemetry-api==1.13.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -60,33 +62,33 @@ opentelemetry-api==1.12.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.3.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.33b0
+opentelemetry-instrumentation==0.34b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-jinja2
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.33b0
+opentelemetry-instrumentation-flask==0.34b0
     # via -r requirements.in
-opentelemetry-instrumentation-jinja2==0.33b0
+opentelemetry-instrumentation-jinja2==0.34b0
     # via -r requirements.in
-opentelemetry-instrumentation-requests==0.33b0
+opentelemetry-instrumentation-requests==0.34b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.33b0
+opentelemetry-instrumentation-wsgi==0.34b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.3.0
     # via -r requirements.in
-opentelemetry-sdk==1.12.0
+opentelemetry-sdk==1.13.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
-opentelemetry-semantic-conventions==0.33b0
+opentelemetry-semantic-conventions==0.34b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.33b0
+opentelemetry-util-http==0.34b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-requests
@@ -133,6 +135,8 @@ wrapt==1.14.1
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-jinja2
+zipp==3.8.1
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/src/userservice/requirements.in
+++ b/src/userservice/requirements.in
@@ -21,11 +21,11 @@ itsdangerous==2.1.2
 jinja2==3.1.2
 markupsafe==2.1.1
 more-itertools==8.14.0
-opentelemetry-sdk==1.12.0
+opentelemetry-sdk==1.13.0
 opentelemetry-exporter-gcp-trace==1.3.0
 opentelemetry-propagator-gcp==1.3.0
-opentelemetry-instrumentation-flask==0.33b0
-opentelemetry-instrumentation-sqlalchemy==0.33b0
+opentelemetry-instrumentation-flask==0.34b0
+opentelemetry-instrumentation-sqlalchemy==0.34b0
 packaging==21.3
 pluggy==1.0.0
 protobuf==4.21.6

--- a/src/userservice/requirements.txt
+++ b/src/userservice/requirements.txt
@@ -77,7 +77,9 @@ idna==3.4
     #   -r requirements.in
     #   requests
 importlib-metadata==4.12.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   flask
 iniconfig==1.1.1
     # via pytest
 itsdangerous==2.1.2
@@ -95,7 +97,7 @@ markupsafe==2.1.1
     #   werkzeug
 more-itertools==8.14.0
     # via -r requirements.in
-opentelemetry-api==1.12.0
+opentelemetry-api==1.13.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -106,30 +108,30 @@ opentelemetry-api==1.12.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.3.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.33b0
+opentelemetry-instrumentation==0.34b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.33b0
+opentelemetry-instrumentation-flask==0.34b0
     # via -r requirements.in
-opentelemetry-instrumentation-sqlalchemy==0.33b0
+opentelemetry-instrumentation-sqlalchemy==0.34b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.33b0
+opentelemetry-instrumentation-wsgi==0.34b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.3.0
     # via -r requirements.in
-opentelemetry-sdk==1.12.0
+opentelemetry-sdk==1.13.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
-opentelemetry-semantic-conventions==0.33b0
+opentelemetry-semantic-conventions==0.34b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.33b0
+opentelemetry-util-http==0.34b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-wsgi


### PR DESCRIPTION
This PR bumps OpenTel to 1.13.0, alongside relevant instrumentation modules.