### PR TITLE
Change Java images from openjdk to eclipse-temurin's JRE

### DIFF
--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -161,7 +161,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17-alpine</image>
+                        <image>eclipse-temurin:17-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -161,7 +161,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17-alpine</image>
+                        <image>eclipse-temurin:17-jre-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -150,7 +150,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17-alpine</image>
+                        <image>eclipse-temurin:17-jre-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -150,7 +150,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17-alpine</image>
+                        <image>eclipse-temurin:17-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -151,7 +151,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17-alpine</image>
+                        <image>eclipse-temurin:17-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -151,7 +151,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17-alpine</image>
+                        <image>eclipse-temurin:17-jre-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -161,7 +161,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>openjdk:17-alpine</image>
+                        <image>eclipse-temurin:17-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -161,7 +161,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17-alpine</image>
+                        <image>eclipse-temurin:17-jre-alpine</image>
                     </from>
                 </configuration>
             </plugin>


### PR DESCRIPTION
OpenJDK is now deprecated (https://hub.docker.com/_/openjdk), so this PR moves the Java images to eclipse-temurin (https://hub.docker.com/_/eclipse-temurin) instead.

Fixes #879 

This idecreases size and reduces the amount of vulnerabilities.

**Size:** 268MB -> 145MB
**Vulns:** 16 -> 1