### PR TITLE
GKE Autopilot Tutorial: Horizontal Pod Autoscaler & GCE ingress examples

### DIFF
--- a/extras/gce-ingress/frontend.yaml
+++ b/extras/gce-ingress/frontend.yaml
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_frontend_ingress_frontend]
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: frontend
+            port:
+              number: 80
+# [END gke_boa_kubernetes_manifests_frontend_ingress_frontend]

--- a/extras/hpa/frontend.yaml
+++ b/extras/hpa/frontend.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_frontend_horizontal_pod_autoscaler_frontend]
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: frontend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: External
+    external:
+      metric:
+        name: loadbalancing.googleapis.com|https|request_count 
+        selector:
+          matchLabels:
+            resource.labels.forwarding_rule_name: <default-frontend>
+      target:
+          type: AverageValue
+          averageValue: 5
+# [END gke_boa_kubernetes_manifests_frontend_horizontal_pod_autoscaler_frontend]

--- a/extras/hpa/userservice.yaml
+++ b/extras/hpa/userservice.yaml
@@ -1,0 +1,34 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_userservice_horizontal_pod_autoscaler_userservice]
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: userservice
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: userservice
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60
+# [END gke_boa_kubernetes_manifests_userservice_horizontal_pod_autoscaler_userservice]


### PR DESCRIPTION
Added HPA manifest examples:

- scale the userservice deployment based on CPU
- scale the frontend service deployment based on the custom metric received from the loadbalancer

Added Ingress manifest example for the frontend service