### PR TITLE
`python:3.10.8-slim`

### DIFF
--- a/src/contacts/Dockerfile
+++ b/src/contacts/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.10-slim
+FROM python:3.10.8-slim
 
 # Set our working directory
 WORKDIR /app

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.10-slim
+FROM python:3.10.8-slim
 
 # Set our working directory
 WORKDIR /app

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.10-slim
+FROM python:3.10.8-slim
 
 # Set our working directory
 WORKDIR /app

--- a/src/userservice/Dockerfile
+++ b/src/userservice/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.10-slim
+FROM python:3.10.8-slim
 
 # Set our working directory
 WORKDIR /app


### PR DESCRIPTION
Like we did in Online Boutique https://github.com/GoogleCloudPlatform/microservices-demo/pull/1168, let's have the Python container base images have now their version as `Ma.Mi.Re` instead of just `Ma.Mi`. As a best practice, this will allow to catch and track CVE vulnerabilities as early as possible.

In this specific case, fixing this: `CVE-2022-40674 | Critical | 9.8 | Yes | expat | OS`.