### PR TITLE
Fix typo in `frontend` container name

### DIFF
--- a/dev-kubernetes-manifests/frontend.yaml
+++ b/dev-kubernetes-manifests/frontend.yaml
@@ -34,7 +34,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       containers:
-      - name: front
+      - name: frontend
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
For consistency, fixing the container name from `front` to `frontend`.

I don't see any breaking change with that. I found this issue when doing Kustomize with the Kubernetes manifests, when patching based on the container name, by consistency, I was taking the name of the service as the container name but found out the hard way that the container name of the `frontend` deployment was `front`.

So proposing this fix. Otherwise in my Kustomize I could just patch the `front` container name, but thought it would be ideal to have this fix for consistency (and maybe avoiding any friction for someone who will try this). Let me know what do you think.