### PR TITLE
`eclipse-temurin:17.0.4.1_1-jre-alpine` + `postgres:15.0-alpine`

### DIFF
--- a/src/accounts-db/Dockerfile
+++ b/src/accounts-db/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM postgres:15-alpine
+FROM postgres:15.0-alpine
 
 # Files for initializing the database.
 COPY initdb/0-accounts-schema.sql /docker-entrypoint-initdb.d/0-accounts-schema.sql

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -161,7 +161,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17-jre-alpine</image>
+                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledger-db/Dockerfile
+++ b/src/ledger-db/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM postgres:15-alpine
+FROM postgres:15.0-alpine
 
 # Need to get coreutils to get the date bash function working properly:
 RUN apk add --update coreutils && rm -rf /var/cache/apk/*

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -150,7 +150,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17-jre-alpine</image>
+                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -151,7 +151,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17-jre-alpine</image>
+                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -161,7 +161,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17-jre-alpine</image>
+                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine</image>
                     </from>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Doesn't change anything yet with the current version because `eclipse-temurin:17-jre-alpine` and `eclipse-temurin:17.0.4.1_1-jre-alpine` are the same as of now (same for `postgres:15-alpine` and `postgres:15.0-alpine`). But it's following up on https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1041 and https://github.com/GoogleCloudPlatform/microservices-demo/pull/1204 in order to better track/catch CVEs vulns fix in the future.