### PR TITLE
Bump greenlet to 2.0.0

### DIFF
--- a/src/contacts/requirements.txt
+++ b/src/contacts/requirements.txt
@@ -63,7 +63,7 @@ googleapis-common-protos==1.56.4
     #   -r requirements.in
     #   google-api-core
     #   grpcio-status
-greenlet==1.1.3.post0
+greenlet==2.0.0
     # via sqlalchemy
 grpcio==1.50.0
     # via

--- a/src/loadgenerator/requirements.txt
+++ b/src/loadgenerator/requirements.txt
@@ -25,13 +25,13 @@ flask-basicauth==0.2.0
     # via locust
 flask-cors==3.0.10
     # via locust
-gevent==22.10.1
+gevent==22.10.2
     # via
     #   geventhttpclient
     #   locust
 geventhttpclient==2.0.8
     # via locust
-greenlet==1.1.3.post0
+greenlet==2.0.0
     # via gevent
 idna==3.4
     # via requests

--- a/src/userservice/requirements.txt
+++ b/src/userservice/requirements.txt
@@ -63,7 +63,7 @@ googleapis-common-protos==1.56.4
     #   -r requirements.in
     #   google-api-core
     #   grpcio-status
-greenlet==1.1.3.post0
+greenlet==2.0.0
     # via sqlalchemy
 grpcio==1.50.0
     # via


### PR DESCRIPTION
This PR bumps greenlet to 2.0.0.

Fixes https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1058 and https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1062