### PR TITLE
Bring unit test JWT token expiry in-line with prod

### DIFF
--- a/src/userservice/tests/test_userservice.py
+++ b/src/userservice/tests/test_userservice.py
@@ -50,7 +50,7 @@ class TestUserservice(unittest.TestCase):
                 'os.environ',
                 {
                     'VERSION': '1',
-                    'TOKEN_EXPIRY_SECONDS': '1',
+                    'TOKEN_EXPIRY_SECONDS': '3600',
                     'PRIV_KEY_PATH': '1',
                     'PUB_KEY_PATH': '1',
                     'ENABLE_TRACING': 'false',


### PR DESCRIPTION
This PR makes sure that the unit test for the userservice are using the same JWT token expiry than prod, which is currently set to 3,600 (https://github.com/GoogleCloudPlatform/bank-of-anthos/blob/main/dev-kubernetes-manifests/userservice.yaml#L62-L63)

This fix is an attempt to fix a flaky test that sometime fails with `jwt.exceptions.ExpiredSignatureError: Signature has expired`, which was seen both on the main branch, and in PRs, e.g.:
- https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1071
- https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1080