### PR TITLE
Add Java 17 to ledgermonolith VM

### DIFF
--- a/src/ledgermonolith/init/install-script.sh
+++ b/src/ledgermonolith/init/install-script.sh
@@ -71,8 +71,11 @@ function apt-install {
 
 
 # Install dependencies from apt
-apt-install openjdk-11-jdk postgresql postgresql-client
+apt-install wget postgresql postgresql-client
 
+# Install Java 17
+wget https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-x64_bin.tar.gz
+sudo tar xf openjdk-*.tar.gz -C /opt
 
 # Install gcloud if not already installed
 gcloud --version > /dev/null
@@ -125,6 +128,8 @@ sudo -u postgres psql --command "ALTER USER postgres WITH PASSWORD '${POSTGRES_P
 cat <<EOF >${MONOLITH_DIR}/ledgermonolith-service.sh
 #!/bin/bash
 source <(sed -E -n 's/[^#]+/export &/ p' ${MONOLITH_DIR}/${APP_ENV})
+export JAVA_HOME=/opt/jdk-17.0.1
+export PATH=\$JAVA_HOME/bin:\$PATH
 java -jar ${MONOLITH_DIR}/${APP_JAR} > ${MONOLITH_LOG}
 EOF
 chmod +x ${MONOLITH_DIR}/ledgermonolith-service.sh


### PR DESCRIPTION
This PR adds Java 17 in the ledgermonolith VM. In the background, I have also just pushed a new version of the ledgermonolith to GCS.

Fixes #1096

I have just finished testing this:
![image](https://user-images.githubusercontent.com/3271352/203177967-2718a4c3-fe14-4a36-bea4-38a50cd0ddff.png)
