### PR TITLE
Fix cleanup workflow when namespace is not found

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -30,7 +30,7 @@ jobs:
           gcloud container clusters get-credentials $PR_CLUSTER \
               --zone $ZONE --project $PROJECT_ID
           NAMESPACE="pr${PR_NUMBER}"
-          kubectl delete namespace $NAMESPACE
+          kubectl delete namespace --ignore-not-found=true $NAMESPACE
         env:
           PROJECT_ID: "bank-of-anthos-ci"
           PR_CLUSTER: "bank-of-anthos-prs"


### PR DESCRIPTION
This fixes an occasional issue where the cleanup workflow is attempting to clean-up a namespace that was already cleaned up previously (i.e. it's "not found"), making sure that the workflow doesn't result in a failure if that's the case.

This was seen in a few PRs, more recently: https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1111

![image](https://user-images.githubusercontent.com/3271352/204320938-0f82173b-6be7-4a77-93a0-9ba42a79e944.png)

![image](https://user-images.githubusercontent.com/3271352/204320974-cdc1c8ff-2f33-41d7-a8c3-f6973dd0b247.png)
