### PR TITLE
Use `digest` instead of `tag` for container base images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,5 +26,8 @@
   },
   "golang":{
     "addLabels": ["lang: go"]
+  },
+  "docker": {
+    "pinDigests": true
   }
 }

--- a/src/accounts-db/Dockerfile
+++ b/src/accounts-db/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM postgres:15.1-alpine
+FROM postgres:15.1-alpine@sha256:44b4073d487d0f9baf82bc95d10e2b1f161b18dcc52cfbd0eb2a894b5e2cd513
 
 # Files for initializing the database.
 COPY initdb/0-accounts-schema.sql /docker-entrypoint-initdb.d/0-accounts-schema.sql

--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -168,7 +168,7 @@
                 <version>3.3.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine</image>
+                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/contacts/Dockerfile
+++ b/src/contacts/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.11.0-slim
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a
 
 # Set our working directory
 WORKDIR /app

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.11.0-slim
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a
 
 # Set our working directory
 WORKDIR /app

--- a/src/ledger-db/Dockerfile
+++ b/src/ledger-db/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM postgres:15.1-alpine
+FROM postgres:15.1-alpine@sha256:44b4073d487d0f9baf82bc95d10e2b1f161b18dcc52cfbd0eb2a894b5e2cd513
 
 # Need to get coreutils to get the date bash function working properly:
 RUN apk add --update coreutils && rm -rf /var/cache/apk/*

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -150,7 +150,7 @@
                 <version>3.3.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine</image>
+                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -158,7 +158,7 @@
                 <version>3.3.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine</image>
+                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.11.0-slim
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a
 
 # Set our working directory
 WORKDIR /app

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -168,7 +168,7 @@
                 <version>3.3.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine</image>
+                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/userservice/Dockerfile
+++ b/src/userservice/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.11.0-slim
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a
 
 # Set our working directory
 WORKDIR /app


### PR DESCRIPTION
Use `digest` instead of `tag` for container base images.

This follows best practices: https://cloud.google.com/architecture/using-container-images.

> We recommend that you pin your Docker images to an exact digest. By pinning to a digest you make your Docker builds immutable, every time you do a pull you get the same content.

And this will allow to catch as early as possible container base images updates when we target images such as: `python:3.11.0-slim`, etc. which are mutable. See illustration there too: https://github.com/GoogleCloudPlatform/microservices-demo/pull/1293#issuecomment-1324140441

Renovate will still update the base images for us: https://docs.renovatebot.com/docker/#digest-updating
