### PR TITLE
Multi-stage build in Python `Dockerfiles` to decrease container image size

### DIFF
--- a/src/contacts/Dockerfile
+++ b/src/contacts/Dockerfile
@@ -13,20 +13,26 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a base
+
+FROM base as builder
+
+# Install dependencies.
+COPY requirements.txt .
+RUN pip install --prefix="/install" -r requirements.txt
+
+FROM base
 
 # Set our working directory
 WORKDIR /app
+
+COPY --from=builder /install /usr/local
 
 # show python logs as they occur
 ENV PYTHONUNBUFFERED=0
 
 # explicitly set a fallback log level in case no log level is defined by Kubernetes
 ENV LOG_LEVEL info
-
-# Install dependencies.
-COPY requirements.txt .
-RUN pip install -r requirements.txt
 
 # Add application code.
 COPY . .

--- a/src/contacts/Dockerfile
+++ b/src/contacts/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a base
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a as base
 
 FROM base as builder
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -13,20 +13,26 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a as base
+
+FROM base as builder
+
+# Install dependencies.
+COPY requirements.txt .
+RUN pip install --prefix="/install" -r requirements.txt
+
+FROM base
 
 # Set our working directory
 WORKDIR /app
+
+COPY --from=builder /install /usr/local
 
 # show python logs as they occur
 ENV PYTHONUNBUFFERED=0
 
 # explicitly set a fallback log level in case no log level is defined by Kubernetes
 ENV LOG_LEVEL info
-
-# Install dependencies.
-COPY requirements.txt .
-RUN pip install -r requirements.txt
 
 # Add application code.
 COPY . .

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -13,10 +13,23 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a as base
+
+FROM base as builder
+
+# Install dependencies.
+COPY requirements.txt .
+RUN pip install --prefix="/install" -r requirements.txt
+
+FROM base
 
 # Set our working directory
 WORKDIR /app
+
+COPY --from=builder /install /usr/local
+
+# Add application code.
+COPY locustfile.py .
 
 # show python logs as they occur
 ENV PYTHONUNBUFFERED=0
@@ -26,13 +39,6 @@ ENV GEVENT_SUPPORT=True
 
 # explicitly set a fallback log level in case no log level is defined by Kubernetes
 ENV LOG_LEVEL info
-
-# Install dependencies.
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-# Add application code.
-COPY locustfile.py .
 
 # start loadgenerator
 ENTRYPOINT locust --host="http://${FRONTEND_ADDR}" --loglevel $LOG_LEVEL --headless --users="${USERS:-10}" 2>&1

--- a/src/userservice/Dockerfile
+++ b/src/userservice/Dockerfile
@@ -13,20 +13,26 @@
 # limitations under the License.
 
 # Use the official Python docker container, slim version, running Debian
-FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a as base
+
+FROM base as builder
+
+# Install dependencies.
+COPY requirements.txt .
+RUN pip install --prefix="/install" -r requirements.txt
+
+FROM base
 
 # Set our working directory
 WORKDIR /app
+
+COPY --from=builder /install /usr/local
 
 # show python logs as they occur
 ENV PYTHONUNBUFFERED=0
 
 # explicitly set a fallback log level in case no log level is defined by Kubernetes
 ENV LOG_LEVEL info
-
-# Install dependencies.
-COPY requirements.txt .
-RUN pip install -r requirements.txt
 
 # Add application code.
 COPY . .


### PR DESCRIPTION
Multi-stage build in Python `Dockerfiles` to decrease container image size (and potentially the surface of attack), like we do there https://github.com/GoogleCloudPlatform/microservices-demo.

- `loadgenerator`: 85.9MB --> 63.1MB (-22.8MB)
- `contacts`: 104.4MB --> 76MB (-28.4MB)
- `frontend`: 79.9MB --> 61.7MB (-18.2MB)
- `userservice`: 104.4MB --> 76MB (-28.4MB)

Note: no change on the number of CVEs.