### PR TITLE
Update renovate.json to look at container images to update in Kubernetes manifests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,5 +29,12 @@
   },
   "docker": {
     "pinDigests": true
+  },
+  "kubernetes": {
+    "fileMatch": ["\\.yaml$"],
+    "ignorePaths": [
+      "dev-kubernetes-manifests/**",
+      "kubernetes-manifests/**"
+    ]
   }
 }


### PR DESCRIPTION
Update renovate.json to look at container images to update in Kubernetes manifests.

It will help for example keeping up to date the container images in these Kubernetes manifests: https://github.com/GoogleCloudPlatform/bank-of-anthos/tree/main/extras/cloudsql/kubernetes-manifests (`gce-proxy`, etc.).

https://docs.renovatebot.com/modules/manager/kubernetes/

As soon as it's merged in `main`, the goal is to catch any update of any container images referenced in any Kubernetes manifests.