### PR TITLE
Adding automerge in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,5 +41,6 @@
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
-    }]
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -36,5 +36,10 @@
       "dev-kubernetes-manifests/**",
       "kubernetes-manifests/**"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
+    }]
 }


### PR DESCRIPTION
### Fixes n/a

### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->
Renovate bot has been noisy. Adding package rules (similar to [online boutique](https://github.com/GoogleCloudPlatform/microservices-demo/pull/1412#issuecomment-1353764698) in auto-merging if tests pass for any dependencies less than minor. 

### Change Summary
<!-- Short summary of the changes submitted -->
Adding `packageRules` ([docs](https://docs.renovatebot.com/configuration-options/#packagerules)). 

### Additional Notes
<!-- Any remaining concerns -->
n/a

### Testing Procedure
Keep an eye our for anything less than a minor bump PR, seeing if it behaves properly!

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
