### PR TITLE
Add platformAutomerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,5 +42,6 @@
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
     }
-  ]
+  ],
+  "platformAutomerge":true
 }


### PR DESCRIPTION
### Fixes n/a

### Background 
We were not seeing the expected automerge behavior

### Change Summary
Added the platform automerge field in the `renovate.json`. [ Doc here](https://docs.renovatebot.com/configuration-options/#platformautomerge)
```
platformAutomerge will configure PRs to be merged after all (if any) branch policies have been me
```


### Additional Notes
none!

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->
n/a
### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
https://github.com/GoogleCloudPlatform/microservices-demo/pull/1420