### PR TITLE
Microservices liveness probes with help of Prometheus 

### DIFF
--- a/extras/prometheus/README.md
+++ b/extras/prometheus/README.md
@@ -1,0 +1,6 @@
+# Prometheus
+
+Directory contains kubernetes manifests to run GMP and OSS Prometheus on GKE cluster.
+
+* `gmp` - directory contains configuration files related to Google Managed Prometheus (GMP)
+* `oss` - directory contains configuration files related to OSS Prometheus (helm chart)

--- a/extras/prometheus/README.md
+++ b/extras/prometheus/README.md
@@ -1,6 +1,6 @@
 # Prometheus
 
-Directory contains kubernetes manifests to run GMP and OSS Prometheus on GKE cluster.
+Directory contains kubernetes manifests to run [Google Managed Prometheus (GMP)](https://cloud.google.com/stackdriver/docs/managed-prometheus) and [Open source software (OSS) Prometheus](https://prometheus.io/) on GKE cluster.
 
-* `gmp` - directory contains configuration files related to Google Managed Prometheus (GMP)
+* `gmp` - directory contains configuration files related to GMP
 * `oss` - directory contains configuration files related to OSS Prometheus (helm chart)

--- a/extras/prometheus/gmp/README.md
+++ b/extras/prometheus/gmp/README.md
@@ -1,8 +1,8 @@
-# GMP on GKE cluster
+# Google Managed Prometheus (GMP) on a GKE cluster
 
-This directory contains files related to configuring probing of Bank of Anthos' microservices with GMP on GKE
+This directory contains files essential to setup liveness probes for Bank of Anthos' microservices running in GKE using GMP.
 
-* `blackbox-exporter.yaml` - Deployment manifest of [Blackbox exporter](https://github.com/prometheus/blackbox_exporter/)
-* `probes.yaml` - File contains GMP PodMonitoring custom resource which scrape metrics from Blackbox Exporter with configuration for each microservice.
-* `rules.yaml` - File contains GMP Rules custom resource
-* `alertmanager.yaml` - File contains configuration of Alertmanager to send notifications to Slack channel via Webhook URL.
+* `blackbox-exporter.yaml` - contains the Deployment definition of [Blackbox exporter](https://github.com/prometheus/blackbox_exporter/)
+* `probes.yaml` - contains the GMP PodMonitoring custom resource definitions per microservice. One monitoring configuration per microservice is defined to be run by the  Blackbox exporter.
+* `rules.yaml` - contains the GMP Rules custom resource definition.
+* `alertmanager.yaml` - contains configuration of Alertmanager to send notifications to Slack channel via Webhook URL.

--- a/extras/prometheus/gmp/README.md
+++ b/extras/prometheus/gmp/README.md
@@ -1,0 +1,8 @@
+# GMP on GKE cluster
+
+This directory contains files related to configuring probing of Bank of Anthos' microservices with GMP on GKE
+
+* `blackbox-exporter.yaml` - Deployment manifest of [Blackbox exporter](https://github.com/prometheus/blackbox_exporter/)
+* `probes.yaml` - File contains GMP PodMonitoring custom resource which scrape metrics from Blackbox Exporter with configuration for each microservice.
+* `rules.yaml` - File contains GMP Rules custom resource
+* `alertmanager.yaml` - File contains configuration of Alertmanager to send notifications to Slack channel via Webhook URL.

--- a/extras/prometheus/gmp/README.md
+++ b/extras/prometheus/gmp/README.md
@@ -2,7 +2,35 @@
 
 This directory contains files essential to setup liveness probes for Bank of Anthos' microservices running in GKE using GMP.
 
-* `blackbox-exporter.yaml` - contains the Deployment definition of [Blackbox exporter](https://github.com/prometheus/blackbox_exporter/).
-* `probes.yaml` - contains the GMP PodMonitoring custom resource definitions per microservice. One monitoring configuration per microservice is defined to be run by the  Blackbox exporter.
-* `rules.yaml` - contains the GMP Rules custom resource definition.
+* `blackbox-exporter.yaml` - contains the Deployment of [Blackbox exporter](https://github.com/prometheus/blackbox_exporter/).
+* `probes.yaml` - contains the GMP PodMonitoring custom resource per microservice. One monitoring configuration per microservice is defined to be run by the Blackbox exporter.
+* `rules.yaml` - contains the GMP Rules custom resource.
 * `alertmanager.yaml` - contains configuration of Alertmanager to send notifications to Slack channel via Webhook URL.
+
+## How to apply configurations
+
+1. Install Bank of Anthos on your GKE cluster
+2. . [Create the Slack application and setup Incoming Webhook.](https://cloud.google.com/kubernetes-engine/docs/tutorials/cluster-notifications-slack#slack_notifications).
+3. Edit `alertmanager.yaml` configuration and store it as a Kubernetes secret.
+
+    ```bash
+    export SLACK_WEBHOOK_URL="<YOUR_SLACK_WEBHOOK_URL>"
+    echo $SLACK_WEBHOOK_URL
+    sed -i "s@SLACK_WEBHOOK_URL@$SLACK_WEBHOOK_URL@g" "alertmanager.yaml"
+    kubectl create secret generic alertmanager \
+        -n gmp-public \
+        --from-file=alertmanager.yaml
+    ```
+
+4. Deploy [Blackbox exporter](https://github.com/prometheus/blackbox_exporter/).
+
+    ```bash
+    kubectl apply -f blackbox-exporter.yaml
+    ```
+
+5. Create GMP custom resources
+
+    ```bash
+    kubectl apply -f probes.yaml
+    kubectl apply -f rules.yaml
+    ```

--- a/extras/prometheus/gmp/README.md
+++ b/extras/prometheus/gmp/README.md
@@ -2,7 +2,7 @@
 
 This directory contains files essential to setup liveness probes for Bank of Anthos' microservices running in GKE using GMP.
 
-* `blackbox-exporter.yaml` - contains the Deployment definition of [Blackbox exporter](https://github.com/prometheus/blackbox_exporter/)
+* `blackbox-exporter.yaml` - contains the Deployment definition of [Blackbox exporter](https://github.com/prometheus/blackbox_exporter/).
 * `probes.yaml` - contains the GMP PodMonitoring custom resource definitions per microservice. One monitoring configuration per microservice is defined to be run by the  Blackbox exporter.
 * `rules.yaml` - contains the GMP Rules custom resource definition.
 * `alertmanager.yaml` - contains configuration of Alertmanager to send notifications to Slack channel via Webhook URL.

--- a/extras/prometheus/gmp/alertmanager.yaml
+++ b/extras/prometheus/gmp/alertmanager.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/extras/prometheus/gmp/alertmanager.yaml
+++ b/extras/prometheus/gmp/alertmanager.yaml
@@ -1,0 +1,47 @@
+global:
+  resolve_timeout: 1m
+
+route:
+  receiver: 'slack-notifications'
+  group_by: [alertname, job, app]
+
+receivers:
+- name: 'slack-notifications'
+  slack_configs:
+  - api_url: SLACK_WEBHOOK_URL
+    send_resolved: true
+    title: |
+      [{{ .Status | toUpper -}}
+      {{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end -}}
+      ] {{ .CommonLabels.alertname }}
+    text: |
+      {{- if eq .CommonLabels.severity "critical" -}}
+      *Severity:* `Critical` :red_circle:
+      {{- else if eq .CommonLabels.severity "warning" -}}
+      *Severity:* `Warning` :warning:
+      {{- else if eq .CommonLabels.severity "info" -}}
+      *Severity:* `Info` :information_source:
+      {{- else -}}
+      *Severity:* `Unknown` :interrobang: {{ .CommonLabels.severity }}
+      {{- end }}
+      {{- if (index .Alerts 0).Annotations.summary }}
+      {{- "\n" -}}
+      *Summary:* {{ (index .Alerts 0).Annotations.summary }}
+      {{- end }}
+      {{- if (index .Alerts 0).Labels.namespace }}
+      {{- "\n" -}}
+      *Namespace:* `{{ (index .Alerts 0).Labels.namespace }}`
+      {{- end }}
+      {{ range .Alerts }}
+          {{- if .Annotations.description }}
+          {{- "\n" -}}
+          {{ .Annotations.description }}
+          {{- "\n" -}}
+          {{- end }}
+          {{- if .Annotations.message }}
+          {{- "\n" -}}
+          {{ .Annotations.message }}
+          {{- "\n" -}}
+          {{- end }}
+      {{- end }}
+    color: '{{ if eq .Status "firing" -}}{{ if eq .CommonLabels.severity "warning" -}}warning{{- else if eq .CommonLabels.severity "critical" -}}danger{{- else -}}#439FE0{{- end -}}{{ else -}}good{{- end }}'

--- a/extras/prometheus/gmp/alertmanager.yaml
+++ b/extras/prometheus/gmp/alertmanager.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 global:
   resolve_timeout: 1m
 

--- a/extras/prometheus/gmp/blackbox-exporter.yaml
+++ b/extras/prometheus/gmp/blackbox-exporter.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/extras/prometheus/gmp/blackbox-exporter.yaml
+++ b/extras/prometheus/gmp/blackbox-exporter.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/extras/prometheus/gmp/blackbox-exporter.yaml
+++ b/extras/prometheus/gmp/blackbox-exporter.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+spec:
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: blackbox-exporter
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: quay.io/prometheus/blackbox-exporter:v0.22.0
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+            ephemeral-storage: 1Gi
+          limits:
+            cpu: 250m
+            memory: 512Mi
+            ephemeral-storage: 1Gi
+        ports:
+        - name: metrics
+          containerPort: 9115
+          protocol: TCP

--- a/extras/prometheus/gmp/probes.yaml
+++ b/extras/prometheus/gmp/probes.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/extras/prometheus/gmp/probes.yaml
+++ b/extras/prometheus/gmp/probes.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: frontend-probe
+  labels:
+    app.kubernetes.io/name: frontend-probe
+spec:
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  endpoints:
+  - port: metrics
+    path: /probe
+    params:
+      target: [frontend:80]
+      module: [http_2xx]
+    timeout: 30s
+    interval: 60s
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: userservice-probe
+  labels:
+    app.kubernetes.io/name: userservice-probe
+spec:
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  endpoints:
+  - port: metrics
+    path: /probe
+    params:
+      target: [userservice:8080/ready]
+      module: [http_2xx]
+    timeout: 30s
+    interval: 60s
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: balancereader-probe
+  labels:
+    app.kubernetes.io/name: balancereader-probe
+spec:
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  endpoints:
+  - port: metrics
+    path: /probe
+    params:
+      target: [balancereader:8080/ready]
+      module: [http_2xx]
+    timeout: 30s
+    interval: 60s
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: contacts-probe
+  labels:
+    app.kubernetes.io/name: contacts-probe
+spec:
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  endpoints:
+  - port: metrics
+    path: /probe
+    params:
+      target: [contacts:8080/ready]
+      module: [http_2xx]
+    timeout: 30s
+    interval: 60s
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: ledgerwriter-probe
+  labels:
+    app.kubernetes.io/name: ledgerwriter-probe
+spec:
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  endpoints:
+  - port: metrics
+    path: /probe
+    params:
+      target: [ledgerwriter:8080/ready]
+      module: [http_2xx]
+    timeout: 30s
+    interval: 60s
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: transactionhistory-probe
+  labels:
+    app.kubernetes.io/name: transactionhistory-probe
+spec:
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  endpoints:
+  - port: metrics
+    path: /probe
+    params:
+      target: [transactionhistory:8080/ready]
+      module: [http_2xx]
+    timeout: 30s
+    interval: 60s

--- a/extras/prometheus/gmp/probes.yaml
+++ b/extras/prometheus/gmp/probes.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: monitoring.googleapis.com/v1
 kind: PodMonitoring

--- a/extras/prometheus/gmp/rules.yaml
+++ b/extras/prometheus/gmp/rules.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: Rules
+metadata:
+  name: uptime-rule
+spec:
+  groups:
+  - name: Micro services uptime
+    interval: 60s
+    rules:
+    - alert: BalancereaderUnavaiable
+      expr: probe_success{job="balancereader-probe"} == 0
+      for: 1m
+      annotations:
+        summary: Balance Reader service is unavailable
+        description: Check Balance Reader pods and it's logs
+      labels:
+        severity: 'critical'
+    - alert: ContactsUnavaiable
+      expr: probe_success{job="contacts-probe"} == 0
+      for: 1m
+      annotations:
+        summary: Contacs service is unavailable
+        description: Check Contacs pods and it's logs
+      labels:
+        severity: 'warning'
+    - alert: FrontendUnavaiable
+      expr: probe_success{job="frontend-probe"} == 0
+      for: 1m
+      annotations:
+        summary: Frontend service is unavailable
+        description: Check Frontend pods and it's logs
+      labels:
+        severity: 'critical'
+    - alert: LedgerwriterUnavaiable
+      expr: probe_success{job="ledgerwriter-probe"} == 0
+      for: 1m
+      annotations:
+        summary: Ledger Writer service is unavailable
+        description: Check Ledger Writer pods and it's logs
+      labels:
+        severity: 'critical'
+    - alert: TransactionhistoryUnavaiable
+      expr: probe_success{job="transactionhistory-probe"} == 0
+      for: 1m
+      annotations:
+        summary: Transaction History service is unavailable
+        description: Check Transaction History pods and it's logs
+      labels:
+        severity: 'critical'
+    - alert: UserserviceUnavaiable
+      expr: probe_success{job="userservice-probe"} == 0
+      for: 1m
+      annotations:
+        summary: User Service is unavailable
+        description: Check User Service pods and it's logs
+      labels:
+        severity: 'critical'

--- a/extras/prometheus/gmp/rules.yaml
+++ b/extras/prometheus/gmp/rules.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ spec:
       expr: probe_success{job="balancereader-probe"} == 0
       for: 1m
       annotations:
-        summary: Balance Reader service is unavailable
+        summary: Balance Reader Service is unavailable
         description: Check Balance Reader pods and it's logs
       labels:
         severity: 'critical'
@@ -33,7 +33,7 @@ spec:
       expr: probe_success{job="contacts-probe"} == 0
       for: 1m
       annotations:
-        summary: Contacs service is unavailable
+        summary: Contacs Service is unavailable
         description: Check Contacs pods and it's logs
       labels:
         severity: 'warning'
@@ -41,7 +41,7 @@ spec:
       expr: probe_success{job="frontend-probe"} == 0
       for: 1m
       annotations:
-        summary: Frontend service is unavailable
+        summary: Frontend Service is unavailable
         description: Check Frontend pods and it's logs
       labels:
         severity: 'critical'
@@ -49,7 +49,7 @@ spec:
       expr: probe_success{job="ledgerwriter-probe"} == 0
       for: 1m
       annotations:
-        summary: Ledger Writer service is unavailable
+        summary: Ledger Writer Service is unavailable
         description: Check Ledger Writer pods and it's logs
       labels:
         severity: 'critical'
@@ -57,7 +57,7 @@ spec:
       expr: probe_success{job="transactionhistory-probe"} == 0
       for: 1m
       annotations:
-        summary: Transaction History service is unavailable
+        summary: Transaction History Service is unavailable
         description: Check Transaction History pods and it's logs
       labels:
         severity: 'critical'

--- a/extras/prometheus/gmp/rules.yaml
+++ b/extras/prometheus/gmp/rules.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: monitoring.googleapis.com/v1
 kind: Rules

--- a/extras/prometheus/oss/README.md
+++ b/extras/prometheus/oss/README.md
@@ -3,6 +3,34 @@
 This directory contains files essential to setup liveness probes for Bank of Anthos' microservices running in GKE using OSS Prometheus.
 
 * `values.yaml` - contains the configurations for the [OSS Prometheus helm chart](https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus).
-* `probes.yaml` - contains the Probe custom resource definitions per microservice. One monitoring configuration per microservice is defined.
-* `rules.yaml` - contains the PrometheusRule custom resource definition.
+* `probes.yaml` - contains the Probe custom resource per microservice. One monitoring configuration per microservice is defined.
+* `rules.yaml` - contains the PrometheusRule custom resource.
 * `alertmanagerconfig.yaml` - contains configuration of AlertmanagerConfig custom resource. This resource defines the configurations necessary to send notifications to a Slack channel via Webhook URL.
+
+## How to apply configurations
+
+1. Install Bank of Anthos on your GKE cluster
+2. Install OSS Prometheus with helm.
+
+    ```bash
+    helm repo add bitnami https://charts.bitnami.com/bitnami
+    helm install tutorial bitnami/kube-prometheus \
+        --version 8.2.2 \
+        --values values.yaml \
+        --wait
+    ```
+
+3. [Create the Slack application and setup Incoming Webhook.](https://cloud.google.com/kubernetes-engine/docs/tutorials/cluster-notifications-slack#slack_notifications).
+4. Create a Kubernetes secret with Slack Webhook Url
+
+    ```bash
+    kubectl create secret generic alertmanager-slack-webhook --from-literal webhookURL=<YOUR_SLACK_WEBHOOK_URL>
+    ```
+
+5. Create OSS Prometheus operator custom resources.
+
+    ```bash
+    kubectl apply -f alertmanagerconfig.yaml
+    kubectl apply -f probes.yaml
+    kubectl apply -f rules.yaml
+    ```

--- a/extras/prometheus/oss/README.md
+++ b/extras/prometheus/oss/README.md
@@ -1,0 +1,8 @@
+# OSS Prometheus on GKE cluster
+
+This directory contains files related to configuring probing of Bank of Anthos' microservices with OSS Prometheus on GKE.
+
+* `values.yaml` - Configuration file to [OSS Prometheus helm chart](https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus)
+* `probes.yaml` - File contains Probe custom resource manifests for each microservice
+* `rules.yaml` - File contains PrometheusRule custom resource
+* `alertmanagerconfig.yaml` - File contain AlertmanagerConfig custom resource with configuration of Alertmanager to send notifications to Slack channel via Webhook URL.

--- a/extras/prometheus/oss/README.md
+++ b/extras/prometheus/oss/README.md
@@ -5,4 +5,4 @@ This directory contains files essential to setup liveness probes for Bank of Ant
 * `values.yaml` - contains the configurations for the [OSS Prometheus helm chart](https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus)
 * `probes.yaml` - contains the Probe custom resource definitions per microservice. One monitoring configuration per microservice is defined.
 * `rules.yaml` - contains the PrometheusRule custom resource definition.
-* `alertmanagerconfig.yaml` - File contain AlertmanagerConfig custom resource with configuration of Alertmanager to send notifications to Slack channel via Webhook URL.
+* `alertmanagerconfig.yaml` - contains configuration of AlertmanagerConfig custom resource . This resource defines the configurations necessary to send notifications to a Slack channel via Webhook URL.

--- a/extras/prometheus/oss/README.md
+++ b/extras/prometheus/oss/README.md
@@ -1,8 +1,8 @@
-# OSS Prometheus on a GKE cluster
+# Open source software (OSS) Prometheus on a GKE cluster
 
 This directory contains files essential to setup liveness probes for Bank of Anthos' microservices running in GKE using OSS Prometheus.
 
-* `values.yaml` - contains the configurations for the [OSS Prometheus helm chart](https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus)
+* `values.yaml` - contains the configurations for the [OSS Prometheus helm chart](https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus).
 * `probes.yaml` - contains the Probe custom resource definitions per microservice. One monitoring configuration per microservice is defined.
 * `rules.yaml` - contains the PrometheusRule custom resource definition.
-* `alertmanagerconfig.yaml` - contains configuration of AlertmanagerConfig custom resource . This resource defines the configurations necessary to send notifications to a Slack channel via Webhook URL.
+* `alertmanagerconfig.yaml` - contains configuration of AlertmanagerConfig custom resource. This resource defines the configurations necessary to send notifications to a Slack channel via Webhook URL.

--- a/extras/prometheus/oss/README.md
+++ b/extras/prometheus/oss/README.md
@@ -1,8 +1,8 @@
-# OSS Prometheus on GKE cluster
+# OSS Prometheus on a GKE cluster
 
-This directory contains files related to configuring probing of Bank of Anthos' microservices with OSS Prometheus on GKE.
+This directory contains files essential to setup liveness probes for Bank of Anthos' microservices running in GKE using OSS Prometheus.
 
-* `values.yaml` - Configuration file to [OSS Prometheus helm chart](https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus)
-* `probes.yaml` - File contains Probe custom resource manifests for each microservice
-* `rules.yaml` - File contains PrometheusRule custom resource
+* `values.yaml` - contains the configurations for the [OSS Prometheus helm chart](https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus)
+* `probes.yaml` - contains the Probe custom resource definitions per microservice. One monitoring configuration per microservice is defined.
+* `rules.yaml` - contains the PrometheusRule custom resource definition.
 * `alertmanagerconfig.yaml` - File contain AlertmanagerConfig custom resource with configuration of Alertmanager to send notifications to Slack channel via Webhook URL.

--- a/extras/prometheus/oss/alertmanagerconfig.yaml
+++ b/extras/prometheus/oss/alertmanagerconfig.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/extras/prometheus/oss/alertmanagerconfig.yaml
+++ b/extras/prometheus/oss/alertmanagerconfig.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: slack-config
+  labels:
+    alertmanagerConfig: slack
+spec:
+  route:
+    receiver: 'slack-notifications'
+    groupBy: [alertname, job, app]
+
+  receivers:
+  - name: 'slack-notifications'
+    slackConfigs:
+    - apiURL:
+        name: alertmanager-slack-webhook
+        key: webhookURL
+      sendResolved: true
+      title: |
+        [{{ .Status | toUpper -}}
+        {{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end -}}
+        ] {{ .CommonLabels.alertname }}
+      text: |
+        {{- if eq .CommonLabels.severity "critical" -}}
+        *Severity:* `Critical` :red_circle:
+        {{- else if eq .CommonLabels.severity "warning" -}}
+        *Severity:* `Warning` :warning:
+        {{- else if eq .CommonLabels.severity "info" -}}
+        *Severity:* `Info` :information_source:
+        {{- else -}}
+        *Severity:* `Unknown` :interrobang: {{ .CommonLabels.severity }}
+        {{- end }}
+        {{- if (index .Alerts 0).Annotations.summary }}
+        {{- "\n" -}}
+        *Summary:* {{ (index .Alerts 0).Annotations.summary }}
+        {{- end }}
+        {{- if (index .Alerts 0).Labels.namespace }}
+        {{- "\n" -}}
+        *Namespace:* `{{ (index .Alerts 0).Labels.namespace }}`
+        {{- end }}
+        {{ range .Alerts }}
+            {{- if .Annotations.description }}
+            {{- "\n" -}}
+            {{ .Annotations.description }}
+            {{- "\n" -}}
+            {{- end }}
+            {{- if .Annotations.message }}
+            {{- "\n" -}}
+            {{ .Annotations.message }}
+            {{- "\n" -}}
+            {{- end }}
+        {{- end }}
+      color: '{{ if eq .Status "firing" -}}{{ if eq .CommonLabels.severity "warning" -}}warning{{- else if eq .CommonLabels.severity "critical" -}}danger{{- else -}}#439FE0{{- end -}}{{ else -}}good{{- end }}'

--- a/extras/prometheus/oss/alertmanagerconfig.yaml
+++ b/extras/prometheus/oss/alertmanagerconfig.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig

--- a/extras/prometheus/oss/probes.yaml
+++ b/extras/prometheus/oss/probes.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/extras/prometheus/oss/probes.yaml
+++ b/extras/prometheus/oss/probes.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Probe

--- a/extras/prometheus/oss/probes.yaml
+++ b/extras/prometheus/oss/probes.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: frontend-probe
+spec:
+  jobName: frontend
+  prober:
+    url: tutorial-kube-prometheus-blackbox-exporter:19115
+    path: /probe
+  module: http_2xx
+  interval: 60s
+  scrapeTimeout: 30s
+  targets:
+    staticConfig:
+      labels:
+        app: bank-of-anthos
+      static:
+        - frontend:80
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: userservice-probe
+spec:
+  jobName: userservice
+  prober:
+    url: tutorial-kube-prometheus-blackbox-exporter:19115
+    path: /probe
+  module: http_2xx
+  interval: 60s
+  scrapeTimeout: 30s
+  targets:
+    staticConfig:
+      labels:
+        app: bank-of-anthos
+      static:
+        - userservice:8080/ready
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: balancereader-probe
+spec:
+  jobName: balancereader
+  prober:
+    url: tutorial-kube-prometheus-blackbox-exporter:19115
+    path: /probe
+  module: http_2xx
+  interval: 60s
+  scrapeTimeout: 30s
+  targets:
+    staticConfig:
+      labels:
+        app: bank-of-anthos
+      static:
+        - balancereader:8080/ready
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: contacts-probe
+spec:
+  jobName: contacts
+  prober:
+    url: tutorial-kube-prometheus-blackbox-exporter:19115
+    path: /probe
+  module: http_2xx
+  interval: 60s
+  scrapeTimeout: 30s
+  targets:
+    staticConfig:
+      labels:
+        app: bank-of-anthos
+      static:
+        - contacts:8080/ready
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: ledgerwriter-probe
+spec:
+  jobName: ledgerwriter
+  prober:
+    url: tutorial-kube-prometheus-blackbox-exporter:19115
+    path: /probe
+  module: http_2xx
+  interval: 60s
+  scrapeTimeout: 30s
+  targets:
+    staticConfig:
+      labels:
+        app: bank-of-anthos
+      static:
+        - ledgerwriter:8080/ready
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: transactionhistory-probe
+spec:
+  jobName: transactionhistory
+  prober:
+    url: tutorial-kube-prometheus-blackbox-exporter:19115
+    path: /probe
+  module: http_2xx
+  interval: 60s
+  scrapeTimeout: 30s
+  targets:
+    staticConfig:
+      labels:
+        app: bank-of-anthos
+      static:
+        - transactionhistory:8080/ready

--- a/extras/prometheus/oss/rules.yaml
+++ b/extras/prometheus/oss/rules.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: uptime-rule
+spec:
+  groups:
+  - name: Micro services uptime
+    interval: 60s
+    rules:
+    - alert: BalancereaderUnavaiable
+      expr: probe_success{app="bank-of-anthos",job="balancereader"} == 0
+      for: 1m
+      annotations:
+        summary: Balance Reader service is unavailable
+        description: Check Balance Reader pods and it's logs
+      labels:
+        severity: 'critical'
+    - alert: ContactsUnavaiable
+      expr: probe_success{app="bank-of-anthos",job="contacts"} == 0
+      for: 1m
+      annotations:
+        summary: Contacs service is unavailable
+        description: Check Contacs pods and it's logs
+      labels:
+        severity: 'warning'
+    - alert: FrontendUnavaiable
+      expr: probe_success{app="bank-of-anthos",job="frontend"} == 0
+      for: 1m
+      annotations:
+        summary: Frontend service is unavailable
+        description: Check Frontend pods and it's logs
+      labels:
+        severity: 'critical'
+    - alert: LedgerwriterUnavaiable
+      expr: probe_success{app="bank-of-anthos",job="ledgerwriter"} == 0
+      for: 1m
+      annotations:
+        summary: Ledger Writer service is unavailable
+        description: Check Ledger Writer pods and it's logs
+      labels:
+        severity: 'critical'
+    - alert: TransactionhistoryUnavaiable
+      expr: probe_success{app="bank-of-anthos",job="transactionhistory"} == 0
+      for: 1m
+      annotations:
+        summary: Transaction History service is unavailable
+        description: Check Transaction History pods and it's logs
+      labels:
+        severity: 'critical'
+    - alert: UserserviceUnavaiable
+      expr: probe_success{app="bank-of-anthos",job="userservice"} == 0
+      for: 1m
+      annotations:
+        summary: User Service is unavailable
+        description: Check User Service pods and it's logs
+      labels:
+        severity: 'critical'

--- a/extras/prometheus/oss/rules.yaml
+++ b/extras/prometheus/oss/rules.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/extras/prometheus/oss/rules.yaml
+++ b/extras/prometheus/oss/rules.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ spec:
       expr: probe_success{app="bank-of-anthos",job="balancereader"} == 0
       for: 1m
       annotations:
-        summary: Balance Reader service is unavailable
+        summary: Balance Reader Service is unavailable
         description: Check Balance Reader pods and it's logs
       labels:
         severity: 'critical'
@@ -33,7 +33,7 @@ spec:
       expr: probe_success{app="bank-of-anthos",job="contacts"} == 0
       for: 1m
       annotations:
-        summary: Contacs service is unavailable
+        summary: Contacs Service is unavailable
         description: Check Contacs pods and it's logs
       labels:
         severity: 'warning'
@@ -41,7 +41,7 @@ spec:
       expr: probe_success{app="bank-of-anthos",job="frontend"} == 0
       for: 1m
       annotations:
-        summary: Frontend service is unavailable
+        summary: Frontend Service is unavailable
         description: Check Frontend pods and it's logs
       labels:
         severity: 'critical'
@@ -49,7 +49,7 @@ spec:
       expr: probe_success{app="bank-of-anthos",job="ledgerwriter"} == 0
       for: 1m
       annotations:
-        summary: Ledger Writer service is unavailable
+        summary: Ledger Writer Service is unavailable
         description: Check Ledger Writer pods and it's logs
       labels:
         severity: 'critical'
@@ -57,7 +57,7 @@ spec:
       expr: probe_success{app="bank-of-anthos",job="transactionhistory"} == 0
       for: 1m
       annotations:
-        summary: Transaction History service is unavailable
+        summary: Transaction History Service is unavailable
         description: Check Transaction History pods and it's logs
       labels:
         severity: 'critical'

--- a/extras/prometheus/oss/values.yaml
+++ b/extras/prometheus/oss/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/extras/prometheus/oss/values.yaml
+++ b/extras/prometheus/oss/values.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 operator:
   resources:
     limits:

--- a/extras/prometheus/oss/values.yaml
+++ b/extras/prometheus/oss/values.yaml
@@ -1,0 +1,66 @@
+operator:
+  resources:
+    limits:
+      cpu: 250m
+      ephemeral-storage: 1Gi
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      ephemeral-storage: 1Gi
+      memory: 512Mi
+  kubeletService:
+    enabled: false
+
+prometheus:
+  resources:
+    limits:
+      cpu: 250m
+      ephemeral-storage: 1Gi
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      ephemeral-storage: 1Gi
+      memory: 512Mi
+
+exporters:
+  node-exporter:
+    enabled: false
+  kube-state-metrics:
+    enabled: false
+kubelet:
+  enabled: false
+kubeApiServer:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+kubeScheduler:
+  enabled: false
+coreDns:
+  enabled: false
+kubeProxy:
+  enabled: false
+
+alertmanager:
+  resources:
+    limits:
+      cpu: 250m
+      ephemeral-storage: 1Gi
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      ephemeral-storage: 1Gi
+      memory: 512Mi
+  configSelector:
+    matchLabels:
+      alertmanagerConfig: slack
+
+blackboxExporter:
+  resources:
+    limits:
+      cpu: 250m
+      ephemeral-storage: 1Gi
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      ephemeral-storage: 1Gi
+      memory: 512Mi


### PR DESCRIPTION
This PR contains manifest files for the setup of the microservices liveness probes with Prometheus (OSS and GMP)

* Configure the liveness probes with help of Blackbox exporter probes
* Configure Alert rules
* Configure Alertmanager to send notifications via Slack channel