### PR TITLE
Upgrade to Spring Boot 3 and Spring Cloud GCP 4

### DIFF
--- a/src/balancereader/pom.xml
+++ b/src/balancereader/pom.xml
@@ -28,18 +28,25 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.8</version>
+        <version>3.0.2</version>
     </parent>
 
     <properties>
         <java.version>17</java.version>
         <bootstrap.version>4.2.1</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
-        <spring-cloud.version>2021.0.5</spring-cloud.version>
+        <spring-cloud.version>2022.0.1</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>4.0.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
@@ -76,12 +83,10 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter</artifactId>
-            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-trace</artifactId>
-            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
+++ b/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
@@ -34,7 +35,7 @@ import org.springframework.context.annotation.Bean;
  *
  * Microservice to track the bank balance for each user account.
  */
-@SpringBootApplication
+@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 public class BalanceReaderApplication {
 
     private static final Logger LOGGER =

--- a/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderController.java
+++ b/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderController.java
@@ -105,7 +105,7 @@ public final class BalanceReaderController {
      */
     @GetMapping("/version")
     public ResponseEntity version() {
-        return new ResponseEntity<String>(version, HttpStatus.OK);
+        return new ResponseEntity<>(version, HttpStatus.OK);
     }
 
     /**
@@ -129,10 +129,10 @@ public final class BalanceReaderController {
         if (!ledgerReader.isAlive()) {
             // Background thread died.
             LOGGER.error("Ledger reader not healthy");
-            return new ResponseEntity<String>("Ledger reader not healthy",
+            return new ResponseEntity<>("Ledger reader not healthy",
                 HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return new ResponseEntity<String>("ok", HttpStatus.OK);
+        return new ResponseEntity<>("ok", HttpStatus.OK);
     }
 
     /**
@@ -158,7 +158,7 @@ public final class BalanceReaderController {
             if (!accountId.equals(jwt.getClaim("acct").asString())) {
                 LOGGER.error("Failed to retrieve account balance: "
                     + "not authorized");
-                return new ResponseEntity<String>("not authorized",
+                return new ResponseEntity<>("not authorized",
                     HttpStatus.UNAUTHORIZED);
             }
             // Load from cache
@@ -166,11 +166,11 @@ public final class BalanceReaderController {
             return new ResponseEntity<Long>(balance, HttpStatus.OK);
         } catch (JWTVerificationException e) {
             LOGGER.error("Failed to retrieve account balance: not authorized");
-            return new ResponseEntity<String>("not authorized",
+            return new ResponseEntity<>("not authorized",
                 HttpStatus.UNAUTHORIZED);
         } catch (ExecutionException | UncheckedExecutionException e) {
             LOGGER.error("Cache error");
-            return new ResponseEntity<String>("cache error",
+            return new ResponseEntity<>("cache error",
                 HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/Transaction.java
+++ b/src/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/Transaction.java
@@ -18,12 +18,12 @@ package anthos.samples.bankofanthos.balancereader;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import org.hibernate.annotations.CreationTimestamp;
 

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -28,18 +28,25 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.8</version>
+        <version>3.0.2</version>
     </parent>
 
     <properties>
         <java.version>17</java.version>
         <bootstrap.version>4.2.1</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
-        <spring-cloud.version>2021.0.5</spring-cloud.version>
+        <spring-cloud.version>2022.0.1</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>4.0.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
@@ -69,12 +76,10 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter</artifactId>
-            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-trace</artifactId>
-            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/LedgerMonolithApplication.java
+++ b/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/LedgerMonolithApplication.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
@@ -28,7 +29,7 @@ import org.springframework.web.client.RestTemplate;
  * Entry point for the LedgerMonolith Spring Boot application.
  *
  */
-@SpringBootApplication
+@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 public class LedgerMonolithApplication {
 
     private static final Logger LOGGER =

--- a/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/LedgerMonolithController.java
+++ b/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/LedgerMonolithController.java
@@ -186,7 +186,7 @@ public final class LedgerMonolithController {
      */
     @GetMapping("/version")
     public ResponseEntity version() {
-        return new ResponseEntity<String>(version, HttpStatus.OK);
+        return new ResponseEntity<>(version, HttpStatus.OK);
     }
 
     /**
@@ -197,7 +197,7 @@ public final class LedgerMonolithController {
     @GetMapping("/ready")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<String> readiness() {
-        return new ResponseEntity<String>(READINESS_CODE, HttpStatus.OK);
+        return new ResponseEntity<>(READINESS_CODE, HttpStatus.OK);
     }
 
       /**
@@ -210,10 +210,10 @@ public final class LedgerMonolithController {
         if (!ledgerReader.isAlive()) {
             // Background thread died.
             LOGGER.error("Ledger reader not healthy");
-            return new ResponseEntity<String>("Ledger reader not healthy",
+            return new ResponseEntity<>("Ledger reader not healthy",
                 HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return new ResponseEntity<String>("ok", HttpStatus.OK);
+        return new ResponseEntity<>("ok", HttpStatus.OK);
     }
 
 
@@ -268,24 +268,24 @@ public final class LedgerMonolithController {
             this.ledgerWriterCache.put(transaction.getRequestUuid(),
                     transaction.getTransactionId());
             LOGGER.info("Submitted transaction successfully");
-            return new ResponseEntity<String>(READINESS_CODE,
+            return new ResponseEntity<>(READINESS_CODE,
                     HttpStatus.CREATED);
 
         } catch (JWTVerificationException e) {
             LOGGER.error("Failed to submit transaction: "
                 + "not authorized");
-            return new ResponseEntity<String>(UNAUTHORIZED_CODE,
+            return new ResponseEntity<>(UNAUTHORIZED_CODE,
                                               HttpStatus.UNAUTHORIZED);
         } catch (IllegalArgumentException | IllegalStateException e) {
             LOGGER.error("Failed to retrieve account balance: "
                 + "bad request");
-            return new ResponseEntity<String>(e.getMessage(),
+            return new ResponseEntity<>(e.getMessage(),
                                               HttpStatus.BAD_REQUEST);
         } catch (ResourceAccessException
                 | CannotCreateTransactionException
                 | HttpServerErrorException e) {
             LOGGER.error("Failed to retrieve account balance");
-            return new ResponseEntity<String>(e.getMessage(),
+            return new ResponseEntity<>(e.getMessage(),
                                               HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -297,7 +297,7 @@ public final class LedgerMonolithController {
      */
     protected Long getAvailableBalance(String accountId) {
         LOGGER.debug("Retrieving balance for transaction sender");
-        Long balance = new Long(-1);
+        Long balance = Long.valueOf(-1);
         try {
             AccountInfo info = ledgerReaderCache.get(accountId);
             balance = info.getBalance();
@@ -332,7 +332,7 @@ public final class LedgerMonolithController {
             if (!accountId.equals(jwt.getClaim("acct").asString())) {
                 LOGGER.error("Failed to retrieve account balance: "
                     + "not authorized");
-                return new ResponseEntity<String>("not authorized",
+                return new ResponseEntity<>("not authorized",
                     HttpStatus.UNAUTHORIZED);
             }
             // Load from cache
@@ -342,11 +342,11 @@ public final class LedgerMonolithController {
             return new ResponseEntity<Long>(balance, HttpStatus.OK);
         } catch (JWTVerificationException e) {
             LOGGER.error("Failed to retrieve account balance: not authorized");
-            return new ResponseEntity<String>("not authorized",
+            return new ResponseEntity<>("not authorized",
                 HttpStatus.UNAUTHORIZED);
         } catch (ExecutionException | UncheckedExecutionException e) {
             LOGGER.error("Cache error");
-            return new ResponseEntity<String>("Account cache error",
+            return new ResponseEntity<>("Account cache error",
                 HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -376,7 +376,7 @@ public final class LedgerMonolithController {
             if (!accountId.equals(jwt.getClaim("acct").asString())) {
                 LOGGER.error("Failed to retrieve account transactions: "
                     + "not authorized");
-                return new ResponseEntity<String>("not authorized",
+                return new ResponseEntity<>("not authorized",
                                                   HttpStatus.UNAUTHORIZED);
             }
 
@@ -399,11 +399,11 @@ public final class LedgerMonolithController {
         } catch (JWTVerificationException e) {
             LOGGER.error("Failed to retrieve account transactions: "
                 + "not authorized");
-            return new ResponseEntity<String>("not authorized",
+            return new ResponseEntity<>("not authorized",
                                               HttpStatus.UNAUTHORIZED);
         } catch (ExecutionException | UncheckedExecutionException e) {
             LOGGER.error("Cache error");
-            return new ResponseEntity<String>("cache error",
+            return new ResponseEntity<>("cache error",
                                               HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/Transaction.java
+++ b/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/Transaction.java
@@ -18,13 +18,13 @@ package anthos.samples.bankofanthos.ledgermonolith;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import org.hibernate.annotations.CreationTimestamp;
 

--- a/src/ledgerwriter/pom.xml
+++ b/src/ledgerwriter/pom.xml
@@ -28,18 +28,25 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.8</version>
+        <version>3.0.2</version>
     </parent>
 
     <properties>
         <java.version>17</java.version>
         <bootstrap.version>4.2.1</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
-        <spring-cloud.version>2021.0.5</spring-cloud.version>
+        <spring-cloud.version>2022.0.1</spring-cloud.version>
     </properties>
 
      <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>4.0.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
@@ -76,12 +83,10 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter</artifactId>
-            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-trace</artifactId>
-            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
+++ b/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
@@ -35,7 +36,7 @@ import org.springframework.web.client.RestTemplate;
  *
  * Microservice to accept new transactions for the bank ledger.
  */
-@SpringBootApplication
+@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 public class LedgerWriterApplication {
 
     private static final Logger LOGGER =

--- a/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterController.java
+++ b/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterController.java
@@ -107,7 +107,7 @@ public final class LedgerWriterController {
      */
     @GetMapping("/version")
     public ResponseEntity version() {
-        return new ResponseEntity<String>(version, HttpStatus.OK);
+        return new ResponseEntity<>(version, HttpStatus.OK);
     }
 
     /**
@@ -118,7 +118,7 @@ public final class LedgerWriterController {
     @GetMapping("/ready")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<String> readiness() {
-        return new ResponseEntity<String>(READINESS_CODE, HttpStatus.OK);
+        return new ResponseEntity<>(READINESS_CODE, HttpStatus.OK);
     }
 
     /**
@@ -172,24 +172,24 @@ public final class LedgerWriterController {
             this.cache.put(transaction.getRequestUuid(),
                     transaction.getTransactionId());
             LOGGER.info("Submitted transaction successfully");
-            return new ResponseEntity<String>(READINESS_CODE,
+            return new ResponseEntity<>(READINESS_CODE,
                     HttpStatus.CREATED);
 
         } catch (JWTVerificationException e) {
             LOGGER.error("Failed to submit transaction: "
                 + "not authorized");
-            return new ResponseEntity<String>(UNAUTHORIZED_CODE,
+            return new ResponseEntity<>(UNAUTHORIZED_CODE,
                                               HttpStatus.UNAUTHORIZED);
         } catch (IllegalArgumentException | IllegalStateException e) {
             LOGGER.error("Failed to retrieve account balance: "
                 + "bad request");
-            return new ResponseEntity<String>(e.getMessage(),
+            return new ResponseEntity<>(e.getMessage(),
                                               HttpStatus.BAD_REQUEST);
         } catch (ResourceAccessException
                 | CannotCreateTransactionException
                 | HttpServerErrorException e) {
             LOGGER.error("Failed to retrieve account balance");
-            return new ResponseEntity<String>(e.getMessage(),
+            return new ResponseEntity<>(e.getMessage(),
                                               HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/Transaction.java
+++ b/src/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/Transaction.java
@@ -18,13 +18,13 @@ package anthos.samples.bankofanthos.ledgerwriter;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import org.hibernate.annotations.CreationTimestamp;
 

--- a/src/transactionhistory/pom.xml
+++ b/src/transactionhistory/pom.xml
@@ -28,18 +28,25 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.8</version>
+        <version>3.0.2</version>
     </parent>
 
     <properties>
         <java.version>17</java.version>
         <bootstrap.version>4.2.1</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
-        <spring-cloud.version>2021.0.5</spring-cloud.version>
+        <spring-cloud.version>2022.0.1</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>4.0.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
@@ -76,12 +83,10 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter</artifactId>
-            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-trace</artifactId>
-            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/Transaction.java
+++ b/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/Transaction.java
@@ -16,18 +16,15 @@
 
 package anthos.samples.bankofanthos.transactionhistory;
 
-import java.util.Date;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-
-import org.hibernate.annotations.CreationTimestamp;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Date;
+import org.hibernate.annotations.CreationTimestamp;
 
 /**
  * Defines a banking transaction.

--- a/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
+++ b/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
@@ -34,7 +35,7 @@ import org.springframework.context.annotation.Bean;
  *
  * Microservice to track the transaction history for each bank account.
  */
-@SpringBootApplication
+@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 public class TransactionHistoryApplication {
 
     private static final Logger LOGGER =

--- a/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
+++ b/src/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
@@ -125,7 +125,7 @@ public final class TransactionHistoryController {
      */
     @GetMapping("/version")
     public ResponseEntity version() {
-        return new ResponseEntity<String>(version, HttpStatus.OK);
+        return new ResponseEntity<>(version, HttpStatus.OK);
     }
 
     /**
@@ -149,10 +149,10 @@ public final class TransactionHistoryController {
         if (!ledgerReader.isAlive()) {
             // background thread died.
             LOGGER.error("Ledger reader not healthy");
-            return new ResponseEntity<String>("Ledger reader not healthy",
+            return new ResponseEntity<>("Ledger reader not healthy",
                                               HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return new ResponseEntity<String>("ok", HttpStatus.OK);
+        return new ResponseEntity<>("ok", HttpStatus.OK);
     }
 
     /**
@@ -177,7 +177,7 @@ public final class TransactionHistoryController {
             if (!accountId.equals(jwt.getClaim("acct").asString())) {
                 LOGGER.error("Failed to retrieve account transactions: "
                     + "not authorized");
-                return new ResponseEntity<String>("not authorized",
+                return new ResponseEntity<>("not authorized",
                                                   HttpStatus.UNAUTHORIZED);
             }
 
@@ -199,11 +199,11 @@ public final class TransactionHistoryController {
         } catch (JWTVerificationException e) {
             LOGGER.error("Failed to retrieve account transactions: "
                 + "not authorized");
-            return new ResponseEntity<String>("not authorized",
+            return new ResponseEntity<>("not authorized",
                                               HttpStatus.UNAUTHORIZED);
         } catch (ExecutionException | UncheckedExecutionException e) {
             LOGGER.error("Cache error");
-            return new ResponseEntity<String>("cache error",
+            return new ResponseEntity<>("cache error",
                                               HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }


### PR DESCRIPTION
### Fixes #1117, #1171, #1217

### Background 
This is a PR to upgrade the project to Spring Boot 3 and Spring Cloud GCP 4.0.

### Change Summary
- Add the Spring Cloud GCP BOM to manage our versions going forward while we’re here.
- Remove the types from our ResponseEntity instantiations.
- Replace all javax.* imports with Jakarta.* counterparts
- Exclude the ZipkinAutoConfiguration with each submodule’s @SpringBootApplication annotation
