### PR TITLE
Bump opentelemetry to 1.16.0

### DIFF
--- a/src/contacts/requirements.in
+++ b/src/contacts/requirements.in
@@ -21,11 +21,11 @@ itsdangerous==2.1.2
 jinja2==3.1.2
 markupsafe==2.1.2
 more-itertools==9.0.0
-opentelemetry-sdk==1.15.0
+opentelemetry-sdk==1.16.0
 opentelemetry-exporter-gcp-trace==1.4.0
 opentelemetry-propagator-gcp==1.4.0
-opentelemetry-instrumentation-flask==0.36b0
-opentelemetry-instrumentation-sqlalchemy==0.36b0
+opentelemetry-instrumentation-flask==0.37b0
+opentelemetry-instrumentation-sqlalchemy==0.37b0
 packaging==23.0
 pluggy==1.0.0
 protobuf==4.22.0

--- a/src/contacts/requirements.txt
+++ b/src/contacts/requirements.txt
@@ -95,7 +95,7 @@ markupsafe==2.1.2
     #   werkzeug
 more-itertools==9.0.0
     # via -r requirements.in
-opentelemetry-api==1.15.0
+opentelemetry-api==1.16.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -106,30 +106,30 @@ opentelemetry-api==1.15.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.4.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.36b0
+opentelemetry-instrumentation==0.37b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.36b0
+opentelemetry-instrumentation-flask==0.37b0
     # via -r requirements.in
-opentelemetry-instrumentation-sqlalchemy==0.36b0
+opentelemetry-instrumentation-sqlalchemy==0.37b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.36b0
+opentelemetry-instrumentation-wsgi==0.37b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.4.0
     # via -r requirements.in
-opentelemetry-sdk==1.15.0
+opentelemetry-sdk==1.16.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
-opentelemetry-semantic-conventions==0.36b0
+opentelemetry-semantic-conventions==0.37b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.36b0
+opentelemetry-util-http==0.37b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-wsgi

--- a/src/frontend/requirements.in
+++ b/src/frontend/requirements.in
@@ -4,9 +4,9 @@ urllib3==1.26.14
 pyjwt==2.6.0
 cryptography==39.0.1
 gunicorn==20.1.0
-opentelemetry-sdk==1.15.0
+opentelemetry-sdk==1.16.0
 opentelemetry-exporter-gcp-trace==1.4.0
 opentelemetry-propagator-gcp==1.4.0
-opentelemetry-instrumentation-flask==0.36b0
-opentelemetry-instrumentation-jinja2==0.36b0
-opentelemetry-instrumentation-requests==0.36b0
+opentelemetry-instrumentation-flask==0.37b0
+opentelemetry-instrumentation-jinja2==0.37b0
+opentelemetry-instrumentation-requests==0.37b0

--- a/src/frontend/requirements.txt
+++ b/src/frontend/requirements.txt
@@ -48,7 +48,7 @@ markupsafe==2.1.2
     # via
     #   jinja2
     #   werkzeug
-opentelemetry-api==1.15.0
+opentelemetry-api==1.16.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -60,33 +60,33 @@ opentelemetry-api==1.15.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.4.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.36b0
+opentelemetry-instrumentation==0.37b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-jinja2
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.36b0
+opentelemetry-instrumentation-flask==0.37b0
     # via -r requirements.in
-opentelemetry-instrumentation-jinja2==0.36b0
+opentelemetry-instrumentation-jinja2==0.37b0
     # via -r requirements.in
-opentelemetry-instrumentation-requests==0.36b0
+opentelemetry-instrumentation-requests==0.37b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.36b0
+opentelemetry-instrumentation-wsgi==0.37b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.4.0
     # via -r requirements.in
-opentelemetry-sdk==1.15.0
+opentelemetry-sdk==1.16.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
-opentelemetry-semantic-conventions==0.36b0
+opentelemetry-semantic-conventions==0.37b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.36b0
+opentelemetry-util-http==0.37b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-requests

--- a/src/userservice/requirements.in
+++ b/src/userservice/requirements.in
@@ -21,11 +21,11 @@ itsdangerous==2.1.2
 jinja2==3.1.2
 markupsafe==2.1.2
 more-itertools==9.0.0
-opentelemetry-sdk==1.15.0
+opentelemetry-sdk==1.16.0
 opentelemetry-exporter-gcp-trace==1.4.0
 opentelemetry-propagator-gcp==1.4.0
-opentelemetry-instrumentation-flask==0.36b0
-opentelemetry-instrumentation-sqlalchemy==0.36b0
+opentelemetry-instrumentation-flask==0.37b0
+opentelemetry-instrumentation-sqlalchemy==0.37b0
 packaging==23.0
 pluggy==1.0.0
 protobuf==4.22.0

--- a/src/userservice/requirements.txt
+++ b/src/userservice/requirements.txt
@@ -95,7 +95,7 @@ markupsafe==2.1.2
     #   werkzeug
 more-itertools==9.0.0
     # via -r requirements.in
-opentelemetry-api==1.15.0
+opentelemetry-api==1.16.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -106,30 +106,30 @@ opentelemetry-api==1.15.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.4.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.36b0
+opentelemetry-instrumentation==0.37b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.36b0
+opentelemetry-instrumentation-flask==0.37b0
     # via -r requirements.in
-opentelemetry-instrumentation-sqlalchemy==0.36b0
+opentelemetry-instrumentation-sqlalchemy==0.37b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.36b0
+opentelemetry-instrumentation-wsgi==0.37b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.4.0
     # via -r requirements.in
-opentelemetry-sdk==1.15.0
+opentelemetry-sdk==1.16.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
-opentelemetry-semantic-conventions==0.36b0
+opentelemetry-semantic-conventions==0.37b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.36b0
+opentelemetry-util-http==0.37b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-wsgi


### PR DESCRIPTION
This PR bumps opentelemetry to version `1.16`.

This takes care of https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1300 and https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1301 while also bumping all relevant modules to `0.37b0`.