### PR TITLE
Add auto-approve bot config

### DIFF
--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
 processes:
   - "PythonDependency"

--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -1,0 +1,4 @@
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
+processes:
+  - "PythonDependency"
+  - "JavaDependency"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*                   @GoogleCloudPlatform/anthos-dpe
+*                   @GoogleCloudPlatform/anthos-dpe @yoshi-approver


### PR DESCRIPTION
This PR enabled the `auto-approve` bot.

Docs: https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve