### PR TITLE
Fix login timeouts when using frontend

### DIFF
--- a/src/frontend/frontend.py
+++ b/src/frontend/frontend.py
@@ -418,7 +418,7 @@ def create_app():
             app.logger.debug('Logging in.')
             req = requests.get(url=app.config["LOGIN_URI"],
                                params={'username': username, 'password': password},
-                               timeout=app.config['BACKEND_TIMEOUT'])
+                               timeout=app.config['BACKEND_TIMEOUT']*2)
             req.raise_for_status()  # Raise on HTTP Status code 4XX or 5XX
 
             # login success


### PR DESCRIPTION
### Background
When logging into bank of anthos through the frontend, oftentimes the login will fail as the userservice takes a while (3-6-ish seconds) to respond and frontend has a default timeout of 4s.

### Change Summary
Doubled the timeout on calling the /login endpoint of the userservice.

### Testing Procedure
Login to bank-of-anthos through frontend

### Related PRs or Issues
Follow-up: https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1221