### PR TITLE
Add trusted-contribution config

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,3 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/trusted-contribution
 trustedContributors:
   - "renovate-bot"
 annotations:

--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,0 +1,5 @@
+trustedContributors:
+  - "renovate-bot"
+annotations:
+  - type: comment
+    text: "/gcbrun"


### PR DESCRIPTION
This PR adds a config for [trusted-contribution](https://github.com/googleapis/repo-automation-bots/tree/main/packages/trusted-contribution) to auto-comment `/gcbrun` on PRs created by [renovate-bot](https://github.com/renovate-bot).

This is required because Cloud Run does not run for external contributors. This is intended behaviour for untrusted contributors, but is inconvenient for trusted bot contributors such as Renovate. This PR prevents us from having to manually comment `/gcbrun` on every incoming Renovate PR.