### PR TITLE
Revert request and limit changes

### DIFF
--- a/src/accounts/contacts/k8s/base/contacts.yaml
+++ b/src/accounts/contacts/k8s/base/contacts.yaml
@@ -61,12 +61,12 @@ spec:
             name: accounts-db-config
         resources:
           requests:
-            cpu: 300m
-            memory: 0.5Gi
+            cpu: 100m
+            memory: 64Mi
             ephemeral-storage: 0.25Gi
           limits:
-            cpu: 300m
-            memory: 0.5Gi
+            cpu: 250m
+            memory: 128Mi
             ephemeral-storage: 0.25Gi
         readinessProbe:
           httpGet:

--- a/src/accounts/userservice/k8s/base/userservice.yaml
+++ b/src/accounts/userservice/k8s/base/userservice.yaml
@@ -75,11 +75,11 @@ spec:
         resources:
           requests:
             cpu: 300m
-            memory: 0.5Gi
+            memory: 128Mi
             ephemeral-storage: 0.25Gi
           limits:
-            cpu: 300m
-            memory: 0.5Gi
+            cpu: 500m
+            memory: 256Mi
             ephemeral-storage: 0.25Gi
 # [END gke_boa_kubernetes_manifests_userservice_deployment_userservice]
 ---

--- a/src/frontend/k8s/base/frontend.yaml
+++ b/src/frontend/k8s/base/frontend.yaml
@@ -113,11 +113,11 @@ spec:
           timeoutSeconds: 30
         resources:
           requests:
-            cpu: 500m
-            memory: 0.25Gi
+            cpu: 100m
+            memory: 64Mi
           limits:
-            cpu: 500m
-            memory: 0.25Gi
+            cpu: 250m
+            memory: 128Mi
 # [END gke_boa_kubernetes_manifests_frontend_deployment_frontend]
 ---
 # [START gke_boa_kubernetes_manifests_frontend_service_frontend]

--- a/src/ledger/balancereader/k8s/base/balancereader.yaml
+++ b/src/ledger/balancereader/k8s/base/balancereader.yaml
@@ -75,12 +75,12 @@ spec:
             name: ledger-db-config
         resources:
           requests:
-            cpu: 300m
-            memory: 568Mi
+            cpu: 100m
+            memory: 256Mi
             ephemeral-storage: 0.5Gi
           limits:
             cpu: 500m
-            memory: 568Mi
+            memory: 512Mi
             ephemeral-storage: 0.5Gi
         readinessProbe:
           httpGet:

--- a/src/ledger/ledgerwriter/k8s/base/ledgerwriter.yaml
+++ b/src/ledger/ledgerwriter/k8s/base/ledgerwriter.yaml
@@ -71,12 +71,12 @@ spec:
             name: ledger-db-config
         resources:
           requests:
-            cpu: 300m
-            memory: 568Mi
+            cpu: 100m
+            memory: 256Mi
             ephemeral-storage: 0.5Gi
           limits:
             cpu: 500m
-            memory: 568Mi
+            memory: 512Mi
             ephemeral-storage: 0.5Gi
         readinessProbe:
           httpGet:

--- a/src/ledger/transactionhistory/k8s/base/transactionhistory.yaml
+++ b/src/ledger/transactionhistory/k8s/base/transactionhistory.yaml
@@ -80,12 +80,12 @@ spec:
             name: ledger-db-config
         resources:
           requests:
-            cpu: 300m
-            memory: 568Mi
+            cpu: 100m
+            memory: 256Mi
             ephemeral-storage: 0.5Gi
           limits:
             cpu: 500m
-            memory: 568Mi
+            memory: 512Mi
             ephemeral-storage: 0.5Gi
         readinessProbe:
           httpGet:


### PR DESCRIPTION
This PR reverts request and limit changes that were done as part of https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1221 to match what is currently in the [latest release](https://github.com/GoogleCloudPlatform/bank-of-anthos/tree/main/kubernetes-manifests). This is due to the fact that the aforementioned increase prevents Bank of Anthos from running in default GKE Standard clusters, which will inevitably break existing tutorial, blog posts, and other content that relies on that staying true.

**Testing**
Deployed on a standard, default, 3-node GKE cluster:
```
~ k get pods
NAME                                  READY   STATUS    RESTARTS   AGE
accounts-db-0                         1/1     Running   0          5m23s
balancereader-7cf585b885-h74p9        1/1     Running   0          4m37s
contacts-fbfd85bdb-cm6mj              1/1     Running   0          5m17s
frontend-f9fbbc5bd-kqpw8              1/1     Running   0          47s
ledger-db-0                           1/1     Running   0          4m42s
ledgerwriter-5455dfc7fd-jq7fn         1/1     Running   0          3m14s
loadgenerator-65cfdb7784-v289v        1/1     Running   0          25s
transactionhistory-56bdcf4949-7x66x   1/1     Running   0          2m1s
userservice-574cddb85d-6jndj          1/1     Running   0          5m
```

Live address: http://35.184.251.221

Nodes:
![image](https://user-images.githubusercontent.com/3271352/229600846-6147efe3-8a91-46c8-b4f9-5337b01d7a0a.png)
