### PR TITLE
Bump userservice by 10Mi

### DIFF
--- a/src/accounts/userservice/k8s/base/userservice.yaml
+++ b/src/accounts/userservice/k8s/base/userservice.yaml
@@ -74,7 +74,7 @@ spec:
           timeoutSeconds: 10
         resources:
           requests:
-            cpu: 250m
+            cpu: 260m
             memory: 128Mi
             ephemeral-storage: 0.25Gi
           limits:


### PR DESCRIPTION
This PR bumps the `userservice` by 10Mi to stay within the 3-node constraints of GKE Standard but to also speed up e2e tests.

Todo: update this description with results once tests have finished running--