### PR TITLE
Bump flask to 2.3.2

### DIFF
--- a/src/accounts/contacts/requirements.in
+++ b/src/accounts/contacts/requirements.in
@@ -7,7 +7,7 @@ cffi==1.15.1
 chardet==5.1.0
 click==8.1.3
 cryptography==40.0.2
-flask==2.2.3
+flask==2.3.2
 google-api-core==2.11.0
 google-auth==2.17.3
 google-cloud-core==2.3.2
@@ -47,6 +47,5 @@ sqlalchemy==1.4.47
 urllib3==1.26.15
 wcwidth==0.2.6
 webencodings==0.5.1
-werkzeug==2.2.3
 wrapt==1.15.0
 zipp==3.15.0

--- a/src/accounts/contacts/requirements.txt
+++ b/src/accounts/contacts/requirements.txt
@@ -10,6 +10,8 @@ bcrypt==4.0.1
     # via -r requirements.in
 bleach==6.0.0
     # via -r requirements.in
+blinker==1.6.2
+    # via flask
 cachetools==5.3.0
     # via
     #   -r requirements.in
@@ -209,8 +211,7 @@ webencodings==0.5.1
     #   -r requirements.in
     #   bleach
 werkzeug==2.3.3
-    # via
-    #   flask
+    # via flask
 wrapt==1.15.0
     # via
     #   -r requirements.in

--- a/src/accounts/contacts/requirements.txt
+++ b/src/accounts/contacts/requirements.txt
@@ -36,7 +36,7 @@ cryptography==40.0.2
     # via -r requirements.in
 deprecated==1.2.13
     # via opentelemetry-api
-flask==2.2.3
+flask==2.3.2
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via
@@ -208,9 +208,8 @@ webencodings==0.5.1
     # via
     #   -r requirements.in
     #   bleach
-werkzeug==2.2.3
+werkzeug==2.3.3
     # via
-    #   -r requirements.in
     #   flask
 wrapt==1.15.0
     # via

--- a/src/accounts/userservice/requirements.in
+++ b/src/accounts/userservice/requirements.in
@@ -7,7 +7,7 @@ cffi==1.15.1
 chardet==5.1.0
 click==8.1.3
 cryptography==40.0.2
-flask==2.2.3
+flask==2.3.2
 google-api-core==2.11.0
 google-auth==2.17.3
 google-cloud-core==2.3.2
@@ -47,6 +47,5 @@ sqlalchemy==1.4.47
 urllib3==1.26.15
 wcwidth==0.2.6
 webencodings==0.5.1
-werkzeug==2.2.3
 wrapt==1.15.0
 zipp==3.15.0

--- a/src/accounts/userservice/requirements.txt
+++ b/src/accounts/userservice/requirements.txt
@@ -10,6 +10,8 @@ bcrypt==4.0.1
     # via -r requirements.in
 bleach==6.0.0
     # via -r requirements.in
+blinker==1.6.2
+    # via flask
 cachetools==5.3.0
     # via
     #   -r requirements.in
@@ -209,8 +211,7 @@ webencodings==0.5.1
     #   -r requirements.in
     #   bleach
 werkzeug==2.3.3
-    # via
-    #   flask
+    # via flask
 wrapt==1.15.0
     # via
     #   -r requirements.in

--- a/src/accounts/userservice/requirements.txt
+++ b/src/accounts/userservice/requirements.txt
@@ -36,7 +36,7 @@ cryptography==40.0.2
     # via -r requirements.in
 deprecated==1.2.13
     # via opentelemetry-api
-flask==2.2.3
+flask==2.3.2
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via
@@ -208,9 +208,8 @@ webencodings==0.5.1
     # via
     #   -r requirements.in
     #   bleach
-werkzeug==2.2.3
+werkzeug==2.3.3
     # via
-    #   -r requirements.in
     #   flask
 wrapt==1.15.0
     # via

--- a/src/frontend/frontend.py
+++ b/src/frontend/frontend.py
@@ -496,7 +496,7 @@ def create_app():
         redirect_uri = request.args['redirect_uri']
         token = request.cookies.get(app.config['TOKEN_NAME'])
 
-        app.logger.debug('Checking consent. consent:' + consent)
+        app.logger.debug('Checking consent. consent: %s', consent)
 
         if consent == "true":
             app.logger.info('User consent granted.')
@@ -665,7 +665,7 @@ def create_app():
             cluster_name = str(req.text)
     except (RequestException, HTTPError) as err:
         app.logger.warning(
-            f"Unable to retrieve cluster name from metadata server {metadata_server}.")
+            "Unable to retrieve cluster name from metadata server %s.", metadata_server)
 
     # get GKE pod name
     pod_name = "unknown"
@@ -680,7 +680,7 @@ def create_app():
         if req.ok:
             pod_zone = str(req.text.split("/")[3])
     except (RequestException, HTTPError) as err:
-        app.logger.warning(f"Unable to retrieve zone from metadata server {metadata_server}.")
+        app.logger.warning("Unable to retrieve zone from metadata server %s.", metadata_server)
 
     # register formater functions
     app.jinja_env.globals.update(format_currency=format_currency)

--- a/src/frontend/requirements.in
+++ b/src/frontend/requirements.in
@@ -1,4 +1,4 @@
-flask==2.2.3
+flask==2.3.2
 requests==2.28.2
 urllib3==1.26.15
 pyjwt==2.6.0

--- a/src/frontend/requirements.txt
+++ b/src/frontend/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+blinker==1.6.2
+    # via flask
 cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7

--- a/src/frontend/requirements.txt
+++ b/src/frontend/requirements.txt
@@ -18,7 +18,7 @@ cryptography==40.0.2
     # via -r requirements.in
 deprecated==1.2.13
     # via opentelemetry-api
-flask==2.2.3
+flask==2.3.2
     # via -r requirements.in
 google-api-core[grpc]==2.11.0
     # via google-cloud-trace
@@ -124,7 +124,7 @@ urllib3==1.26.15
     # via
     #   -r requirements.in
     #   requests
-werkzeug==2.3.2
+werkzeug==2.3.3
     # via flask
 wrapt==1.15.0
     # via

--- a/src/loadgenerator/requirements.txt
+++ b/src/loadgenerator/requirements.txt
@@ -18,7 +18,7 @@ click==8.1.3
     # via flask
 configargparse==1.5.3
     # via locust
-flask==2.3.1
+flask==2.3.2
     # via
     #   flask-basicauth
     #   flask-cors
@@ -65,7 +65,7 @@ typing-extensions==4.5.0
     # via locust
 urllib3==1.26.15
     # via requests
-werkzeug==2.3.2
+werkzeug==2.3.3
     # via
     #   flask
     #   locust


### PR DESCRIPTION
This PR bumps flask to 2.3.2, fixing:
- https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1477
- https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1478
- https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1479