### PR TITLE
Add dependabot as trusted contributor

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -15,6 +15,7 @@
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/trusted-contribution
 trustedContributors:
   - "renovate-bot"
+  - "dependabot"
 annotations:
   - type: comment
     text: "/gcbrun"


### PR DESCRIPTION
This PR adds `dependabot` to the list of trusted contributors, which will auto-comment `/gcbrun` (Cloud Build) to comment this bot opens.