### PR TITLE
Add Python and Docker extensions to auto-approve

### DIFF
--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -15,4 +15,6 @@
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
 processes:
   - "PythonDependency"
+  - "PythonSampleAppDependency"
   - "JavaDependency"
+  - "DockerDependency"


### PR DESCRIPTION
This PR adds a few new auto-approve extensions to Bank of Anthos, which were released here: https://github.com/googleapis/repo-automation-bots/pull/5053