### PR TITLE
Bump OpenTel to 1.19.0

### DIFF
--- a/src/accounts/contacts/requirements.in
+++ b/src/accounts/contacts/requirements.in
@@ -21,11 +21,11 @@ itsdangerous==2.1.2
 jinja2==3.1.2
 markupsafe==2.1.3
 more-itertools==9.1.0
-opentelemetry-sdk==1.18.0
+opentelemetry-sdk==1.19.0
 opentelemetry-exporter-gcp-trace==1.5.0
 opentelemetry-propagator-gcp==1.5.0
-opentelemetry-instrumentation-flask==0.39b0
-opentelemetry-instrumentation-sqlalchemy==0.39b0
+opentelemetry-instrumentation-flask==0.40b0
+opentelemetry-instrumentation-sqlalchemy==0.40b0
 packaging==23.1
 pluggy==1.2.0
 protobuf==4.23.4

--- a/src/accounts/contacts/requirements.txt
+++ b/src/accounts/contacts/requirements.txt
@@ -34,7 +34,7 @@ click==8.1.5
     #   flask
 coverage[toml]==7.2.7
     # via pytest-cov
-cryptography==41.0.2
+cryptography==41.0.1
     # via -r requirements.in
 deprecated==1.2.14
     # via opentelemetry-api
@@ -97,7 +97,7 @@ markupsafe==2.1.3
     #   werkzeug
 more-itertools==9.1.0
     # via -r requirements.in
-opentelemetry-api==1.18.0
+opentelemetry-api==1.19.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -109,39 +109,40 @@ opentelemetry-api==1.18.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.5.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.39b0
+opentelemetry-instrumentation==0.40b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.39b0
+opentelemetry-instrumentation-flask==0.40b0
     # via -r requirements.in
-opentelemetry-instrumentation-sqlalchemy==0.39b0
+opentelemetry-instrumentation-sqlalchemy==0.40b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.39b0
+opentelemetry-instrumentation-wsgi==0.40b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.5.0
     # via -r requirements.in
 opentelemetry-resourcedetector-gcp==1.5.0a0
     # via opentelemetry-exporter-gcp-trace
-opentelemetry-sdk==1.18.0
+opentelemetry-sdk==1.19.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-resourcedetector-gcp
-opentelemetry-semantic-conventions==0.39b0
+opentelemetry-semantic-conventions==0.40b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.39b0
+opentelemetry-util-http==0.40b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-wsgi
 packaging==23.1
     # via
     #   -r requirements.in
+    #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   pytest
 pluggy==1.2.0

--- a/src/accounts/userservice/requirements.in
+++ b/src/accounts/userservice/requirements.in
@@ -21,11 +21,11 @@ itsdangerous==2.1.2
 jinja2==3.1.2
 markupsafe==2.1.3
 more-itertools==9.1.0
-opentelemetry-sdk==1.18.0
+opentelemetry-sdk==1.19.0
 opentelemetry-exporter-gcp-trace==1.5.0
 opentelemetry-propagator-gcp==1.5.0
-opentelemetry-instrumentation-flask==0.39b0
-opentelemetry-instrumentation-sqlalchemy==0.39b0
+opentelemetry-instrumentation-flask==0.40b0
+opentelemetry-instrumentation-sqlalchemy==0.40b0
 packaging==23.1
 pluggy==1.2.0
 protobuf==4.23.4

--- a/src/accounts/userservice/requirements.txt
+++ b/src/accounts/userservice/requirements.txt
@@ -34,7 +34,7 @@ click==8.1.5
     #   flask
 coverage[toml]==7.2.7
     # via pytest-cov
-cryptography==41.0.2
+cryptography==41.0.1
     # via -r requirements.in
 deprecated==1.2.14
     # via opentelemetry-api
@@ -97,7 +97,7 @@ markupsafe==2.1.3
     #   werkzeug
 more-itertools==9.1.0
     # via -r requirements.in
-opentelemetry-api==1.18.0
+opentelemetry-api==1.19.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -109,39 +109,40 @@ opentelemetry-api==1.18.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.5.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.39b0
+opentelemetry-instrumentation==0.40b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.39b0
+opentelemetry-instrumentation-flask==0.40b0
     # via -r requirements.in
-opentelemetry-instrumentation-sqlalchemy==0.39b0
+opentelemetry-instrumentation-sqlalchemy==0.40b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.39b0
+opentelemetry-instrumentation-wsgi==0.40b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.5.0
     # via -r requirements.in
 opentelemetry-resourcedetector-gcp==1.5.0a0
     # via opentelemetry-exporter-gcp-trace
-opentelemetry-sdk==1.18.0
+opentelemetry-sdk==1.19.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-resourcedetector-gcp
-opentelemetry-semantic-conventions==0.39b0
+opentelemetry-semantic-conventions==0.40b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.39b0
+opentelemetry-util-http==0.40b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-wsgi
 packaging==23.1
     # via
     #   -r requirements.in
+    #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   pytest
 pluggy==1.2.0

--- a/src/frontend/requirements.in
+++ b/src/frontend/requirements.in
@@ -5,9 +5,9 @@ pyjwt==2.7.0
 cryptography==41.0.1
 gunicorn==20.1.0
 google-auth==2.17.3
-opentelemetry-sdk==1.18.0
+opentelemetry-sdk==1.19.0
 opentelemetry-exporter-gcp-trace==1.5.0
 opentelemetry-propagator-gcp==1.5.0
-opentelemetry-instrumentation-flask==0.39b0
-opentelemetry-instrumentation-jinja2==0.39b0
-opentelemetry-instrumentation-requests==0.39b0
+opentelemetry-instrumentation-flask==0.40b0
+opentelemetry-instrumentation-jinja2==0.40b0
+opentelemetry-instrumentation-requests==0.40b0

--- a/src/frontend/requirements.txt
+++ b/src/frontend/requirements.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.2.0
     # via requests
 click==8.1.5
     # via flask
-cryptography==41.0.2
+cryptography==41.0.1
     # via -r requirements.in
 deprecated==1.2.14
     # via opentelemetry-api
@@ -44,7 +44,7 @@ gunicorn==20.1.0
     # via -r requirements.in
 idna==3.4
     # via requests
-importlib-metadata==6.0.1
+importlib-metadata==6.8.0
     # via opentelemetry-api
 itsdangerous==2.1.2
     # via flask
@@ -54,7 +54,7 @@ markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
-opentelemetry-api==1.18.0
+opentelemetry-api==1.19.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -67,40 +67,42 @@ opentelemetry-api==1.18.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.5.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.39b0
+opentelemetry-instrumentation==0.40b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-jinja2
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.39b0
+opentelemetry-instrumentation-flask==0.40b0
     # via -r requirements.in
-opentelemetry-instrumentation-jinja2==0.39b0
+opentelemetry-instrumentation-jinja2==0.40b0
     # via -r requirements.in
-opentelemetry-instrumentation-requests==0.39b0
+opentelemetry-instrumentation-requests==0.40b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.39b0
+opentelemetry-instrumentation-wsgi==0.40b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.5.0
     # via -r requirements.in
 opentelemetry-resourcedetector-gcp==1.5.0a0
     # via opentelemetry-exporter-gcp-trace
-opentelemetry-sdk==1.18.0
+opentelemetry-sdk==1.19.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-resourcedetector-gcp
-opentelemetry-semantic-conventions==0.39b0
+opentelemetry-semantic-conventions==0.40b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.39b0
+opentelemetry-util-http==0.40b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
+packaging==23.1
+    # via opentelemetry-instrumentation-flask
 proto-plus==1.22.3
     # via google-cloud-trace
 protobuf==4.23.4


### PR DESCRIPTION
This PR bumps OpenTel to `1.19.0`, and relevant modules to `0.40b`.