### PR TITLE
Bump skaffold to 2.6.1

### DIFF
--- a/src/accounts/cloudbuild.yaml
+++ b/src/accounts/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
   - name: gcr.io/cloud-builders/gsutil
     id: download-skaffold-cache
     args: ['cp', $_CACHE_URI, '/workspace/cache'] # always write skaffold cache to filename cache in workspace
-  - name: gcr.io/k8s-skaffold/skaffold:v2.3.1
+  - name: gcr.io/k8s-skaffold/skaffold:v2.6.1
     id: build-and-push-images
     args:
       - "skaffold"
@@ -28,7 +28,7 @@ steps:
   - name: gcr.io/cloud-builders/gsutil
     id: upload-skaffold-cache
     args: ['cp', '/workspace/$_CACHE',  $_CACHE_URI]
-  - name: gcr.io/k8s-skaffold/skaffold:v2.3.1 # python set up should be baked into a custom builder image to speed up build times
+  - name: gcr.io/k8s-skaffold/skaffold:v2.6.1 # python set up should be baked into a custom builder image to speed up build times
     id: run-tests
     script: |
       #!/bin/bash

--- a/src/frontend/cloudbuild.yaml
+++ b/src/frontend/cloudbuild.yaml
@@ -15,7 +15,7 @@
 steps:
   - name: gcr.io/cloud-builders/gsutil
     args: ['cp', $_CACHE_URI, '/workspace/cache'] # always write skaffold cache to filename cache in workspace
-  - name: gcr.io/k8s-skaffold/skaffold:v2.3.1-lts
+  - name: gcr.io/k8s-skaffold/skaffold:v2.6.1
     args:
       - "skaffold"
       - "build"
@@ -25,7 +25,7 @@ steps:
       - "--module=$_TEAM"
   - name: gcr.io/cloud-builders/gsutil
     args: ['cp', '/workspace/$_CACHE',  $_CACHE_URI]
-  - name: gcr.io/k8s-skaffold/skaffold:v2.3.1-lts # python set up should be baked into a custom builder image to speed up build times
+  - name: gcr.io/k8s-skaffold/skaffold:v2.6.1 # python set up should be baked into a custom builder image to speed up build times
     script: |
       #!/bin/bash
       apt-get update

--- a/src/ledger/cloudbuild.yaml
+++ b/src/ledger/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
   - name: gcr.io/cloud-builders/gsutil
     id: download-skaffold-cache
     args: ['cp', $_CACHE_URI, '/workspace/cache'] # always write skaffold cache to filename cache in workspace
-  - name: gcr.io/k8s-skaffold/skaffold:v2.1.0
+  - name: gcr.io/k8s-skaffold/skaffold:v2.6.1
     id: build-and-push-images
     args:
       - "skaffold"
@@ -28,7 +28,7 @@ steps:
   - name: gcr.io/cloud-builders/gsutil
     id: upload-skaffold-cache
     args: ['cp', '/workspace/$_CACHE',  $_CACHE_URI]
-  - name: gcr.io/k8s-skaffold/skaffold:v2.1.0
+  - name: gcr.io/k8s-skaffold/skaffold:v2.6.1
     id: run-tests
     script: MAVEN_USER_HOME=$MAVEN_USER_HOME skaffold test --build-artifacts=/workspace/artifacts.json --module=$SERVICE --assume-yes
     env:


### PR DESCRIPTION
This PR bumps Skaffold images used in Cloud Build for `2.6.1`.