### PR TITLE
Bump cryptography to 41.0.3

### DIFF
--- a/src/accounts/contacts/requirements.in
+++ b/src/accounts/contacts/requirements.in
@@ -6,7 +6,7 @@ certifi==2023.7.22
 cffi==1.15.1
 chardet==5.1.0
 click==8.1.6
-cryptography==41.0.2
+cryptography==41.0.3
 flask==2.3.2
 google-api-core==2.11.1
 google-auth==2.17.3

--- a/src/accounts/userservice/requirements.in
+++ b/src/accounts/userservice/requirements.in
@@ -6,7 +6,7 @@ certifi==2023.7.22
 cffi==1.15.1
 chardet==5.1.0
 click==8.1.6
-cryptography==41.0.2
+cryptography==41.0.3
 flask==2.3.2
 google-api-core==2.11.1
 google-auth==2.17.3

--- a/src/frontend/requirements.in
+++ b/src/frontend/requirements.in
@@ -2,7 +2,7 @@ flask==2.3.2
 requests==2.31.0
 urllib3==2.0.4
 pyjwt==2.8.0
-cryptography==41.0.2
+cryptography==41.0.3
 gunicorn==21.2.0
 google-auth==2.17.3
 opentelemetry-sdk==1.19.0


### PR DESCRIPTION
This PR bumps `cryptography` to `41.0.3` in the `.in` files to `41.0.3` (the `.txt` files were caught by https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1687)