### PR TITLE
cleanup: Use e2 series machine instead of n1 for the ledgermonolith VM

### DIFF
--- a/src/ledgermonolith/scripts/deploy-monolith.sh
+++ b/src/ledgermonolith/scripts/deploy-monolith.sh
@@ -64,7 +64,7 @@ gcloud compute instances create ledgermonolith-service \
     --subnet ${SUBNET=default} \
     --image-family=debian-10 \
     --image-project=debian-cloud \
-    --machine-type=n1-standard-1 \
+    --machine-type=e2-medium \
     --scopes cloud-platform,storage-ro \
     --metadata gcs-bucket=${GCS_BUCKET},VmDnsSetting=ZonalPreferred \
     --metadata-from-file startup-script=${CWD}/../init/install-script.sh \


### PR DESCRIPTION
This repo is used in the Anthos labs in Qwiklabs. We are asking every lab developer to stop using N1 series machines and use only E2 series machines, which are cheaper to run and less prone to resource starvation issues.

## Before
![image](https://github.com/GoogleCloudPlatform/bank-of-anthos/assets/3271352/819736cf-8417-496e-8cf5-334e50b31c41)

## After
![image](https://github.com/GoogleCloudPlatform/bank-of-anthos/assets/3271352/1b2dcf32-0169-4d9d-b435-6c55f56bf7fe)