### PR TITLE
Example of usage Backup for GKE

### DIFF
--- a/extras/backup/README.md
+++ b/extras/backup/README.md
@@ -40,6 +40,7 @@ For example to migrate from GKE Standart to GKE Autopilot cluster in other regio
   ```bash
   kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" apply -f extras/jwt
   kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" apply -f kubernetes-manifests/
+  kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" delete statefulset accounts-db ledger-db
   kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" apply -f extras/backup/kubernetes-manifests/
   ```
 
@@ -87,7 +88,7 @@ For example to migrate from GKE Standart to GKE Autopilot cluster in other regio
     --cluster="projects/${PROJECT_ID}/locations/us-east1/clusters/destination-cluster" \
     --namespaced-resource-restore-mode="delete-and-restore" \
     --selected-namespaces="default" \
-    --substitution-rules-file="extras/backup/substitution-rules.yaml" \
+    --transformation-rules-file="extras/backup/transformation-rules.yaml" \
     --volume-data-restore-policy="restore-volume-data-from-backup"
   ```
 

--- a/extras/backup/README.md
+++ b/extras/backup/README.md
@@ -1,0 +1,130 @@
+# Backup for GKE
+
+This directory contains files essential to demonstrate Backup for GKE service functionality.
+
+For example to migrate from GKE Standart to GKE Autopilot cluster in other region.
+
+## Steps
+
+1. Create GKE Standard as Source cluster
+
+  ```bash
+  gcloud beta container clusters create "source-cluster" \
+    --region="us-central1" \
+    --addons="BackupRestore,HttpLoadBalancing"
+  ```
+
+1. Create GKE Autopilot as Destination cluster
+
+  ```bash
+  gcloud beta container clusters create-auto "destination-cluster" \
+    --region="us-east1"
+  ```
+
+1. Enable Backup for GKE in Destination cluster
+
+  ```bash
+  gcloud container clusters update "${GKE_AUTOPILOT}" \
+    --region="us-east1" \
+    --update-addons="BackupRestore=ENABLED"
+  ```
+
+1. Create External Global IP
+
+  ```bash
+  gcloud compute addresses create "bank-of-anthos" --global
+  ```
+
+1. Deploy the Bank of Anthos to Source cluster
+
+  ```bash
+  kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" apply -f extras/jwt
+  kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" apply -f kubernetes-manifests/
+  kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" apply -f extras/backup/kubernetes-manifests/
+  ```
+
+1. Access BoA and populate some data
+
+1. Prepare for backup. Shutdown databases to avoid write operations
+
+  ```bash
+  kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" scale statefulset accounts-db --replicas 0
+  kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" scale statefulset ledger-db --replicas 0
+  ```
+
+1. Create a backup plan
+
+  ```bash
+  gcloud beta container backup-restore backup-plans create "standard-backup-plan" \
+    --location="us-central1" \
+    --cluster="projects/${PROJECT_ID}/locations/us-central1/clusters/source-cluster" \
+    --selected-namespaces="default" \
+    --include-secrets \
+    --include-volume-data
+  ```
+
+1. Make a backup
+
+  ```bash
+  gcloud beta container backup-restore backups create "standard-backup" \
+    --location="us-central1" \
+    --backup-plan="standard-backup-plan" \
+    --wait-for-completion
+  ```
+
+1. Prepare to restore app by deleting ingress
+
+  ```bash
+  kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" delete ingress frontend
+  ```
+
+1. Create restore plan
+
+  ```bash
+  gcloud beta container backup-restore restore-plans create "autopilot-restore-plan" \
+    --location="us-east1" \
+    --backup-plan="projects/${PROJECT_ID}/locations/us-central1/backupPlans/standard-backup-plan" \
+    --cluster="projects/${PROJECT_ID}/locations/us-east1/clusters/destination-cluster" \
+    --namespaced-resource-restore-mode="delete-and-restore" \
+    --selected-namespaces="default" \
+    --substitution-rules-file="extras/backup/substitution-rules.yaml" \
+    --volume-data-restore-policy="restore-volume-data-from-backup"
+  ```
+
+1. Restore BoA app to Destination cluster
+
+  ```bash
+  gcloud beta container backup-restore restores create "autopilot-restore" \
+    --location="us-east1" \
+    --restore-plan="autopilot-restore-plan" \
+    --backup="projects/${PROJECT_ID}/locations/us-central1/backupPlans/standard-backup-plan/backups/standard-backup" \
+    --wait-for-completion
+  ```
+
+1. Wait while BoA spinup in Destination cluster and check that populated data still there
+
+1. Clean up
+
+  ```bash
+  kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" delete -f extras/backup/kubernetes-manifests/
+  kubectl --context="gke_${PROJECT_ID}_us-central1_source-cluster" delete -f kubernetes-manifests/
+  kubectl --context="gke_${PROJECT_ID}_us-east1_destination-cluster" delete -f extras/backup/kubernetes-manifests/
+  kubectl --context="gke_${PROJECT_ID}_us-east1_destination-cluster" delete -f kubernetes-manifests/
+
+  gcloud beta container backup-restore restores delete "autopilot-restore" \
+    --location="us-east1" \
+    --restore-plan="autopilot-restore-plan" \
+    --quiet
+  gcloud beta container backup-restore restore-plans delete "autopilot-restore-plan" \
+    --location="us-east1" \
+    --quiet
+  gcloud beta container backup-restore backups delete "standard-backup" \
+    --location="us-central1" \
+    --backup-plan="standard-backup-plan" \
+    --quiet
+  gcloud beta container backup-restore backup-plans delete "standard-backup-plan" \
+    --location="us-central1" \
+    --quiet
+  gcloud container clusters delete "source-cluster" --zone="us-central1" --quiet
+  gcloud container clusters delete "destination-cluster" --region="us-east1" --quiet
+  ```

--- a/extras/backup/kubernetes-manifests/accounts-db.yaml
+++ b/extras/backup/kubernetes-manifests/accounts-db.yaml
@@ -1,0 +1,88 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: accounts-db
+    application: bank-of-anthos
+    environment: development
+    team: accounts
+    tier: db
+  name: accounts-db
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: standard-rwo
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    application: bank-of-anthos
+    environment: development
+    team: accounts
+    tier: db
+  name: accounts-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: accounts-db
+      application: bank-of-anthos
+      environment: development
+      team: accounts
+      tier: db
+  serviceName: accounts-db
+  template:
+    metadata:
+      labels:
+        app: accounts-db
+        application: bank-of-anthos
+        environment: development
+        team: accounts
+        tier: db
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: accounts-db-config
+        - configMapRef:
+            name: demo-data-config
+        image: us-central1-docker.pkg.dev/bank-of-anthos-ci/bank-of-anthos/accounts-db:v0.6.1@sha256:7c4cf161904b4ef869cc8796d7b5bcde1dda6f861898c0cfed6afd4e4affe659
+        name: accounts-db
+        ports:
+        - containerPort: 5432
+        resources:
+          limits:
+            cpu: 250m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgresdb
+          subPath: postgres
+      serviceAccountName: default
+      volumes:
+      - name: postgresdb
+        persistentVolumeClaim:
+          claimName: accounts-db

--- a/extras/backup/kubernetes-manifests/ingress.yaml
+++ b/extras/backup/kubernetes-manifests/ingress.yaml
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    application: bank-of-anthos
+    environment: development
+    team: frontend
+    tier: web
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: bank-of-anthos
+    kubernetes.io/ingress.class: gce
+  name: frontend
+spec:
+  defaultBackend:
+    service:
+      name: frontend
+      port:
+        number: 80

--- a/extras/backup/kubernetes-manifests/ledger-db.yaml
+++ b/extras/backup/kubernetes-manifests/ledger-db.yaml
@@ -1,0 +1,88 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: ledger-db
+    application: bank-of-anthos
+    environment: development
+    team: ledger
+    tier: db
+  name: ledger-db
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: standard-rwo
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    application: bank-of-anthos
+    environment: development
+    team: ledger
+    tier: db
+  name: ledger-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ledger-db
+      application: bank-of-anthos
+      environment: development
+      team: ledger
+      tier: db
+  serviceName: ledger-db
+  template:
+    metadata:
+      labels:
+        app: ledger-db
+        application: bank-of-anthos
+        environment: development
+        team: ledger
+        tier: db
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: ledger-db-config
+        - configMapRef:
+            name: demo-data-config
+        image: us-central1-docker.pkg.dev/bank-of-anthos-ci/bank-of-anthos/ledger-db:v0.6.1@sha256:2fe07029725a4ae2cf7beaec17dbdd6f8fc11caa8a9725708b42a603532e7b84
+        name: postgres
+        ports:
+        - containerPort: 5432
+        resources:
+          limits:
+            cpu: 250m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgresdb
+          subPath: postgres
+      serviceAccountName: default
+      volumes:
+      - name: postgresdb
+        persistentVolumeClaim:
+          claimName: ledger-db

--- a/extras/backup/substitution-rules.yaml
+++ b/extras/backup/substitution-rules.yaml
@@ -1,0 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+substitutionRules:
+- targetNamespaces:
+  - default
+  targetGroupKinds:
+  - resourceGroup: apps
+    resourceKind: StatefulSet
+  targetJsonPath: "{$.spec.replicas}"
+  newValue: '1'

--- a/extras/backup/transformation-rules.yaml
+++ b/extras/backup/transformation-rules.yaml
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-substitutionRules:
-- targetNamespaces:
-  - default
-  targetGroupKinds:
-  - resourceGroup: apps
-    resourceKind: StatefulSet
-  targetJsonPath: "{$.spec.replicas}"
-  newValue: '1'
+transformationRules:
+- description: Recover one replica to StatefulSets
+  resourceFilter:
+    groupKinds:
+    - resourceGroup: apps
+      resourceKind: StatefulSet
+    namespaces:
+    - default
+  fieldActions:
+  - op: REPLACE
+    path: "/spec/replicas"
+    value: '1'

--- a/src/accounts/accounts-db/k8s/overlays/development/kustomization.yaml
+++ b/src/accounts/accounts-db/k8s/overlays/development/kustomization.yaml
@@ -14,8 +14,11 @@
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  tier: db
 resources:
   - ../../base
   - accounts-db.yaml
 components:
+  - ../../../../components/accounts
   - ../../../../../components/development

--- a/src/ledger/ledger-db/k8s/base/config.yaml
+++ b/src/ledger/ledger-db/k8s/base/config.yaml
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: ledger-db-config
-    labels:
-      app: postgres
-  data:
-    POSTGRES_DB: postgresdb
-    POSTGRES_USER: admin
-    POSTGRES_PASSWORD: password
-    SPRING_DATASOURCE_URL: jdbc:postgresql://ledger-db:5432/postgresdb
-    SPRING_DATASOURCE_USERNAME: admin # should match POSTGRES_USER
-    SPRING_DATASOURCE_PASSWORD: password # should match POSTGRES_PASSWORD
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ledger-db-config
+  labels:
+    app: ledger-db
+data:
+  POSTGRES_DB: postgresdb
+  POSTGRES_USER: admin
+  POSTGRES_PASSWORD: password
+  SPRING_DATASOURCE_URL: jdbc:postgresql://ledger-db:5432/postgresdb
+  SPRING_DATASOURCE_USERNAME: admin # should match POSTGRES_USER
+  SPRING_DATASOURCE_PASSWORD: password # should match POSTGRES_PASSWORD

--- a/src/ledger/ledger-db/k8s/overlays/development/kustomization.yaml
+++ b/src/ledger/ledger-db/k8s/overlays/development/kustomization.yaml
@@ -14,8 +14,11 @@
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  tier: db
 resources:
   - ../../base
   - ledger-db.yaml
 components:
+  - ../../../components/ledger
   - ../../../../../components/development

--- a/src/ledger/ledger-db/k8s/overlays/development/kustomization.yaml
+++ b/src/ledger/ledger-db/k8s/overlays/development/kustomization.yaml
@@ -20,5 +20,5 @@ resources:
   - ../../base
   - ledger-db.yaml
 components:
-  - ../../../components/ledger
+  - ../../../../components/ledger
   - ../../../../../components/development


### PR DESCRIPTION
This PR contains files and changes to demonstrate the usage of Backup for GKE in the scope of migration from Standard to Autopilot.

I have added additional labels to account-db and ledger-db development manifests to make them similar to other workloads. Also, these changes are needed for the tutorial. Unfortunately, I can't move this PR to `kubernetes-engine-samples` repo because the tutorial is based on BoA application. 