### PR TITLE
Bump opentel to 1.20.0

### DIFF
--- a/src/accounts/contacts/requirements.in
+++ b/src/accounts/contacts/requirements.in
@@ -21,11 +21,11 @@ itsdangerous==2.1.2
 jinja2==3.1.2
 markupsafe==2.1.3
 more-itertools==10.1.0
-opentelemetry-sdk==1.19.0
+opentelemetry-sdk==1.20.0
 opentelemetry-exporter-gcp-trace==1.5.0
 opentelemetry-propagator-gcp==1.5.0
-opentelemetry-instrumentation-flask==0.40b0
-opentelemetry-instrumentation-sqlalchemy==0.40b0
+opentelemetry-instrumentation-flask==0.41b0
+opentelemetry-instrumentation-sqlalchemy==0.41b0
 packaging==23.1
 pluggy==1.3.0
 protobuf==4.24.3

--- a/src/accounts/contacts/requirements.txt
+++ b/src/accounts/contacts/requirements.txt
@@ -97,7 +97,7 @@ markupsafe==2.1.3
     #   werkzeug
 more-itertools==10.1.0
     # via -r requirements.in
-opentelemetry-api==1.19.0
+opentelemetry-api==1.20.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -109,33 +109,33 @@ opentelemetry-api==1.19.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.5.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.40b0
+opentelemetry-instrumentation==0.41b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.40b0
+opentelemetry-instrumentation-flask==0.41b0
     # via -r requirements.in
-opentelemetry-instrumentation-sqlalchemy==0.40b0
+opentelemetry-instrumentation-sqlalchemy==0.41b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.40b0
+opentelemetry-instrumentation-wsgi==0.41b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.5.0
     # via -r requirements.in
 opentelemetry-resourcedetector-gcp==1.5.0a0
     # via opentelemetry-exporter-gcp-trace
-opentelemetry-sdk==1.19.0
+opentelemetry-sdk==1.20.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-resourcedetector-gcp
-opentelemetry-semantic-conventions==0.40b0
+opentelemetry-semantic-conventions==0.41b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.40b0
+opentelemetry-util-http==0.41b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-wsgi
@@ -207,7 +207,7 @@ six==1.16.0
     #   google-auth
 sqlalchemy==1.4.49
     # via -r requirements.in
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   opentelemetry-resourcedetector-gcp
     #   opentelemetry-sdk

--- a/src/accounts/userservice/requirements.in
+++ b/src/accounts/userservice/requirements.in
@@ -21,11 +21,11 @@ itsdangerous==2.1.2
 jinja2==3.1.2
 markupsafe==2.1.3
 more-itertools==10.1.0
-opentelemetry-sdk==1.19.0
+opentelemetry-sdk==1.20.0
 opentelemetry-exporter-gcp-trace==1.5.0
 opentelemetry-propagator-gcp==1.5.0
-opentelemetry-instrumentation-flask==0.40b0
-opentelemetry-instrumentation-sqlalchemy==0.40b0
+opentelemetry-instrumentation-flask==0.41b0
+opentelemetry-instrumentation-sqlalchemy==0.41b0
 packaging==23.1
 pluggy==1.3.0
 protobuf==4.24.3

--- a/src/accounts/userservice/requirements.txt
+++ b/src/accounts/userservice/requirements.txt
@@ -97,7 +97,7 @@ markupsafe==2.1.3
     #   werkzeug
 more-itertools==10.1.0
     # via -r requirements.in
-opentelemetry-api==1.19.0
+opentelemetry-api==1.20.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -109,33 +109,33 @@ opentelemetry-api==1.19.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.5.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.40b0
+opentelemetry-instrumentation==0.41b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.40b0
+opentelemetry-instrumentation-flask==0.41b0
     # via -r requirements.in
-opentelemetry-instrumentation-sqlalchemy==0.40b0
+opentelemetry-instrumentation-sqlalchemy==0.41b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.40b0
+opentelemetry-instrumentation-wsgi==0.41b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.5.0
     # via -r requirements.in
 opentelemetry-resourcedetector-gcp==1.5.0a0
     # via opentelemetry-exporter-gcp-trace
-opentelemetry-sdk==1.19.0
+opentelemetry-sdk==1.20.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-resourcedetector-gcp
-opentelemetry-semantic-conventions==0.40b0
+opentelemetry-semantic-conventions==0.41b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.40b0
+opentelemetry-util-http==0.41b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-wsgi
@@ -207,7 +207,7 @@ six==1.16.0
     #   google-auth
 sqlalchemy==1.4.49
     # via -r requirements.in
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   opentelemetry-resourcedetector-gcp
     #   opentelemetry-sdk

--- a/src/frontend/requirements.in
+++ b/src/frontend/requirements.in
@@ -5,9 +5,9 @@ pyjwt==2.8.0
 cryptography==41.0.3
 gunicorn==21.2.0
 google-auth==2.17.3
-opentelemetry-sdk==1.19.0
+opentelemetry-sdk==1.20.0
 opentelemetry-exporter-gcp-trace==1.5.0
 opentelemetry-propagator-gcp==1.5.0
-opentelemetry-instrumentation-flask==0.40b0
-opentelemetry-instrumentation-jinja2==0.40b0
-opentelemetry-instrumentation-requests==0.40b0
+opentelemetry-instrumentation-flask==0.41b0
+opentelemetry-instrumentation-jinja2==0.41b0
+opentelemetry-instrumentation-requests==0.41b0

--- a/src/frontend/requirements.txt
+++ b/src/frontend/requirements.txt
@@ -54,7 +54,7 @@ markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
-opentelemetry-api==1.19.0
+opentelemetry-api==1.20.0
     # via
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-instrumentation
@@ -67,36 +67,36 @@ opentelemetry-api==1.19.0
     #   opentelemetry-sdk
 opentelemetry-exporter-gcp-trace==1.5.0
     # via -r requirements.in
-opentelemetry-instrumentation==0.40b0
+opentelemetry-instrumentation==0.41b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-jinja2
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.40b0
+opentelemetry-instrumentation-flask==0.41b0
     # via -r requirements.in
-opentelemetry-instrumentation-jinja2==0.40b0
+opentelemetry-instrumentation-jinja2==0.41b0
     # via -r requirements.in
-opentelemetry-instrumentation-requests==0.40b0
+opentelemetry-instrumentation-requests==0.41b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.40b0
+opentelemetry-instrumentation-wsgi==0.41b0
     # via opentelemetry-instrumentation-flask
 opentelemetry-propagator-gcp==1.5.0
     # via -r requirements.in
 opentelemetry-resourcedetector-gcp==1.5.0a0
     # via opentelemetry-exporter-gcp-trace
-opentelemetry-sdk==1.19.0
+opentelemetry-sdk==1.20.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-gcp-trace
     #   opentelemetry-resourcedetector-gcp
-opentelemetry-semantic-conventions==0.40b0
+opentelemetry-semantic-conventions==0.41b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.40b0
+opentelemetry-util-http==0.41b0
     # via
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-requests
@@ -133,7 +133,7 @@ rsa==4.9
     # via google-auth
 six==1.16.0
     # via google-auth
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   opentelemetry-resourcedetector-gcp
     #   opentelemetry-sdk
@@ -148,7 +148,7 @@ wrapt==1.15.0
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-jinja2
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This PR manually bumps OpenTel to 1.20, fixing:
- https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1773
- https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1774