### PR TITLE
Update pom.xml to use src/main/resources

### DIFF
--- a/src/ledger/balancereader/pom.xml
+++ b/src/ledger/balancereader/pom.xml
@@ -168,7 +168,7 @@
     <build>
         <resources>
             <resource>
-                <directory>src</directory>
+                <directory>src/main/resources</directory>
             </resource>
         </resources>
         <plugins>

--- a/src/ledger/ledgerwriter/pom.xml
+++ b/src/ledger/ledgerwriter/pom.xml
@@ -158,7 +158,7 @@
     <build>
         <resources>
             <resource>
-                <directory>src</directory>
+                <directory>src/main/resources</directory>
             </resource>
         </resources>
         <plugins>

--- a/src/ledger/transactionhistory/pom.xml
+++ b/src/ledger/transactionhistory/pom.xml
@@ -168,7 +168,7 @@
     <build>
         <resources>
             <resource>
-                <directory>src</directory>
+                <directory>src/main/resources</directory>
             </resource>
         </resources>
         <plugins>


### PR DESCRIPTION
### Background 
* The `<resources>` element inside the `pom.xml` file tells the project (`balancereader` microservice in this case) where its [project resources](https://maven.apache.org/plugins/maven-resources-plugin/examples/resource-directory.html) are. Project resources includes the [`application.properties` file](https://github.com/GoogleCloudPlatform/bank-of-anthos/blob/release/v0.6.1/src/ledger/balancereader/src/main/resources/application.properties).
* Currently, the `pom.xml` points to `src/` while the `application.properties` file exists in the `src/main/resources` folder.
* So the `balancereader` never picks up on its [`application.properties` file](https://github.com/GoogleCloudPlatform/bank-of-anthos/blob/release/v0.6.1/src/ledger/balancereader/src/main/resources/application.properties).
* This issue also exists in `ledgerwriter`, and `transactionhistory`.

### Change Summary
* Update the `pom.xml` file of `balancereader`, `ledgerwriter`, and `transactionhistory` to pick up on the application.properties file in the `src/main/resources` folder.

### Additional Notes
* See https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1794 for evidence that the `balancereader` never picks up on the `application.properties` file.
     * In that pull-request, I first [changed the `{PORT}` value](https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/1794/commits/2e1b3d27f91ca1d4325f1b765a7f3ace00667fac) inside the `application.properties` file, without updating [the port in the K8s YAML of `balancereader`](https://github.com/GoogleCloudPlatform/bank-of-anthos/blob/main/src/ledger/balancereader/k8s/base/balancereader.yaml#L115). The change still successfully deployed — which it shouldn't have.
     * After that, I updated the `pom.xml` file to use `src/main/resources`. Then, deployment failed.

### Testing Procedure
* The GitHub check that deploys this change on a GKE cluster should suffice + the testing detailed in "Additional Notes", in my opinion.

### Related PRs or Issues 
* It's possible that https://github.com/GoogleCloudPlatform/bank-of-anthos/issues/1354 is fixed by this pull-request.
