### PR TITLE
Remove preview skaffold version from Cloud Build / Deploy step

### DIFF
--- a/src/accounts/cloudbuild.yaml
+++ b/src/accounts/cloudbuild.yaml
@@ -54,6 +54,5 @@ steps:
       - "--skaffold-file=src/$_TEAM/$_SERVICE/skaffold.yaml"
       - "--region=$LOCATION"
       - "--gcs-source-staging-dir=$_SOURCE_STAGING_BUCKET/$SHORT_SHA"
-      - "--skaffold-version=skaffold_preview"
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/src/frontend/cloudbuild.yaml
+++ b/src/frontend/cloudbuild.yaml
@@ -49,6 +49,5 @@ steps:
       - "--skaffold-file=src/$_TEAM/skaffold.yaml"
       - "--region=$LOCATION"
       - "--gcs-source-staging-dir=$_SOURCE_STAGING_BUCKET/$SHORT_SHA"
-      - "--skaffold-version=skaffold_preview"
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/src/ledger/cloudbuild.yaml
+++ b/src/ledger/cloudbuild.yaml
@@ -48,7 +48,6 @@ steps:
       - "--skaffold-file=src/$_TEAM/$_SERVICE/skaffold.yaml"
       - "--region=$LOCATION"
       - "--gcs-source-staging-dir=$_SOURCE_STAGING_BUCKET/$SHORT_SHA"
-      - "--skaffold-version=skaffold_preview"
 options:
   logging: CLOUD_LOGGING_ONLY
   env:


### PR DESCRIPTION
This PR removes the experimental Skaffold version flag from the Cloud Deploy release creation. This flag used to be necessary when it was added since we were relying on Skaffold changes that were not included in the default Cloud Deploy release, but nowadays Cloud Deploy uses Skaffold 2.6 by default which is more than sufficient for our needs.