### PR TITLE
build: Add GitHub bot to check license headers

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -30,18 +30,17 @@ allowedLicenses:
 # ignoreLicenseYear: true # Useful when migrating in code licensed at previous years.
 
 sourceFileExtensions:
-  - 'cs'
+  - 'css'
   - 'Dockerfile'
   - 'gitignore'
   - 'go'
+  - 'html'
   - 'java'
   - 'js'
-  - 'php'
+  - 'properties'
   - 'py'
-  - 'rb'
   - 'sh'
   - 'sql'
   - 'tf'
   - 'yaml'
   - 'yml'
-  

--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,47 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file configures a GitHub Bot called "License Header Lint GCF": https://github.com/apps/license-header-lint-gcf
+# The bot runs a GitHub check called "header-check" (inside pull-requests) that warns us about invalid/missing license headers.
+# The schema for this configutation file is documented at https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint#header-checker-lint.
+
+allowedCopyrightHolders:
+  - 'Google LLC'
+
+allowedLicenses:
+  - 'Apache-2.0'
+
+# If you want to ignore certain files/folders, use ignoreFiles.
+# ignoreFiles:
+#  - '**/requirements.txt'
+
+# If you want to ignore checking the license year, use ignoreLicenseYear.
+# ignoreLicenseYear: true # Useful when migrating in code licensed at previous years.
+
+sourceFileExtensions:
+  - 'cs'
+  - 'Dockerfile'
+  - 'gitignore'
+  - 'go'
+  - 'java'
+  - 'js'
+  - 'php'
+  - 'py'
+  - 'rb'
+  - 'sh'
+  - 'sql'
+  - 'tf'
+  - 'yaml'
+  - 'yml'
+  


### PR DESCRIPTION
### Fixes #1887

### Background 
* See #1887.
* See [docs about configuring the bot](https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint#header-checker-lint).
* It's unreasonable to expect that we cover all possible file extensions for this repo, so (for now), let's just cover comment-supporting file extensions that appear at least 3 or more times.
* I used [a command](https://stackoverflow.com/a/55317141) to check the frequency of each file extension. Warning: The command misses files without dots (e.g., Dockerfile, Makefile). See output below:
```
 157 yaml ✅ 
  54 class
  47 md
  35 java ✅ 
  28 tf ✅ 
  20 xml
  20 py ✅ 
  14 txt
  14 sh ✅ 
  14 pack
  14 idx
  13 sample
  13 png
  12 properties ✅ 
  12 lst
  11 js ✅ 
   9 html ✅ 
   8 css ✅ 
   6 rev
   6 mockmaker
   6 json
   6 gitignore ✅ 
   5 prefs
   5 jar
   4 original
   4 in
   3 yml ✅ 
   3 sql ✅ 
   3 id
   3 dockerignore
   3 digest
   3 conf
   2 tfvars
   2 project
   2 key
   2 exec
   2 ds_store
   1 template
   1 svg
   1 pylintrc
   1 factorypath
   1 env
   1 csr
   1 crt
   1 cmd
   1 classpath
```
* ✅  = included in header-checker-lint.yml
* I've also included `Dockerfile` which isn't capture by the above command/output because it doesn't contain a dot.
* **How to review:** Notice the `header-check` GitHub check running against this pull-request.
* If you want to see a failing example, see [this kubernetes-engine-samples pull-request](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/964).
