### PR TITLE
feat(renovate): group PRs by language and schedule weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,15 +1,22 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended",
+    ":approveMajorUpdates",
   ],
+  // Run once a week, outside typical office hours.
+  // TZ is UTC unless specified.
+  "schedule": [ "after 10pm on Tuesday" ],
   "pip-compile": {
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"]
   },
+  // pip-compile handles requirements.txt updates.
+  "pip_requirements": {
+    "enabled": false
+  },
   "constraints": {
     "python": "~=3.11.0"
   },
-  "prConcurrentLimit":10,
   "stabilityDays":7,
   "vulnerabilityAlerts":{
      "labels":[
@@ -18,25 +25,25 @@
      "stabilityDays":0
   },
   "labels": ["dependencies"],
-  "python":{
-    "addLabels": ["lang: python"]
-  },
-  "java":{
-    "addLabels": ["lang: java"]
-  },
-  "golang":{
-    "addLabels": ["lang: go"]
-  },
-  "docker": {
-    "pinDigests": true
-  },
   "kubernetes": {
     "fileMatch": ["\\.yaml$"],
     "ignorePaths": [
-      "kubernetes-manifests/**"
+      "release/**",
+      "kustomize/base/**"
     ]
   },
+  // Dependency Dashboard should be excluded from SLO calculation.
+  "dependencyDashboardLabels": [
+    "type: process",
+  ],
   "packageRules": [
+    // Label PRs based on the languages they contain
+    // category ids are listed at https://docs.renovatebot.com/modules/manager/
+    {"matchCategories": ["python"], "addLabels": ["lang: python"]},
+    {"matchCategories": ["java"], "addLabels": ["lang: java"]},
+    {"matchCategories": ["golang"], "addLabels": ["lang: go"]},
+    {"matchCategories": ["js"], "addLabels": ["lang: nodejs"]},
+    {"matchCategories": ["dotnet"], "addLabels": ["lang: dotnet"]},
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
@@ -45,11 +52,51 @@
       "matchDepTypes": ["devDependencies"],
       "automerge": true
     },
+    // OpenTelemetry: include pre-release versions of python instrumentation
+    // packages. These packages are tightly coupled with otel api and sdk.
     {
-      "description": "group all OTel deps, as they have tight version coupling",
-      "groupName": "opentelemetry",
-      "matchPackagePrefixes": ["opentelemetry-"]
-    }
+      "matchPackagePrefixes": ["opentelemetry-instrumentation"],
+      "ignoreUnstable": false,
+      "matchDatasources": ["pypi"]
+    },
+    // Group PRs by "category" - usually language.
+    {
+      "matchCategories": ["python"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "python",
+      "automerge": true
+    },
+    {
+      "matchCategories": ["java"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "java",
+      "automerge": true
+    },
+    {
+      "matchCategories": ["golang"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "golang",
+      "automerge": true
+    },
+    {
+      "matchCategories": ["js"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "nodejs",
+      "automerge": true
+    },
+    {
+      "matchCategories": ["dotnet"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "dotnet",
+      "automerge": true
+    },
+    {
+      "matchCategories": ["docker"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "docker",
+      "pinDigests": true,
+      "automerge": true
+    },
   ],
   "platformAutomerge":true
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,6 @@
     "fileMatch": ["\\.yaml$"],
     "ignorePaths": [
       "kubernetes-manifests/**",
-      "kustomize/base/**"
     ]
   },
   // Dependency Dashboard should be excluded from SLO calculation.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,7 +28,7 @@
   "kubernetes": {
     "fileMatch": ["\\.yaml$"],
     "ignorePaths": [
-      "release/**",
+      "kubernetes-manifests/**",
       "kustomize/base/**"
     ]
   },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,7 @@
   "stabilityDays":7,
   "vulnerabilityAlerts":{
      "labels":[
-       "type:security" 
+       "type:security"
      ],
      "stabilityDays":0
   },
@@ -44,6 +44,11 @@
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true
+    },
+    {
+      "description": "group all OTel deps, as they have tight version coupling",
+      "groupName": "opentelemetry",
+      "matchPackagePrefixes": ["opentelemetry-"]
     }
   ],
   "platformAutomerge":true


### PR DESCRIPTION
This new renovate config will run weekly, and group PRs based on the "language"
(actually the renovate manager).

This should reduce the number of PRs and PR conflicts significantly, down to
~5/wk instead of ~15. And eliminate issues with tightly-coupled dependencies.

