### PR TITLE
Change live demo domain to cymbal.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!-- @todo: https://github.com/badges/shields/pull/7759 -->
 ![GitHub branch checks state](https://img.shields.io/github/checks-status/GoogleCloudPlatform/bank-of-anthos/main)
-[![Website](https://img.shields.io/website?label=live%20demo&url=https%3A%2F%2Fbank-of-anthos.xyz%2F)](https://bank-of-anthos.xyz)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fcymbal-bank.fsi.cymbal.dev%2F&label=live%20demo
+)](https://cymbal-bank.fsi.cymbal.dev)
 
 # Bank of Anthos
 

--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -1,6 +1,6 @@
 # CI/CD pipeline
 
-This document introduces the CI/CD pipeline that powers Bank of Anthos' production instance (hosted here: https://bank-of-anthos.xyz/) as well as how you can get started deploying it in your own Google Cloud project (with your own domain name).
+This document introduces the CI/CD pipeline that powers Bank of Anthos' production instance (hosted here: https://cymbal-bank.fsi.cymbal.dev/) as well as how you can get started deploying it in your own Google Cloud project (with your own domain name).
 
 **Note**: This is a more advanced view of Bank of Anthos and is _not_ required to deploy Bank of Anthos or any of its deployment options. Instead, this is meant to showcase how one can deploy a full end-to-end CI/CD environment with [Cloud Build](https://cloud.google.com/build) and [Cloud Deploy](https://cloud.google.com/deploy), with the help of [Terraform](https://www.terraform.io/), [Skaffold](https://skaffold.dev/), and [Kustomize](https://kustomize.io/). The end result is multiple environments in a multi-stage pipeline (development, staging, production) which features [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine), [Anthos Config Management (ACM)](https://cloud.google.com/anthos/config-management), [Anthos Service Mesh (ASM)](https://cloud.google.com/anthos/service-mesh), and [Cloud SQL](https://cloud.google.com/sql/docs).
 
@@ -104,10 +104,10 @@ These steps are necessary for all Google Cloud projects that are _not_ `bank-of-
    # run from repository root
    find iac/tf-multienv-cicd-anthos-autopilot/* -type f -exec sed -i 's/bank-of-anthos-tf-state/'"$PROJECT_ID-boa-tf-state"'/g' {} +
    ```
-1. Replace all occurrences of `bank-of-anthos.xyz` in the Terraform scripts with your domain name.
+1. Replace all occurrences of `cymbal-bank.fsi.cymbal.dev` in the Terraform scripts with your domain name.
    ```sh
    # run from repository root
-   find src/frontend/* -type f -exec sed -i 's/bank-of-anthos.xyz/'"$DOMAIN"'/g' {} +
+   find src/frontend/* -type f -exec sed -i 's/cymbal-bank.fsi.cymbal.dev/'"$DOMAIN"'/g' {} +
    ```
 1. Commit and push your changes to your repository.
    ```sh

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -93,7 +93,7 @@ Once the release notes are published, you should then replace the version of the
 
 3. Wait for all promotion builds to be green.
 
-4. Verify that the production environment is still up and running: https://bank-of-anthos.xyz
+4. Verify that the production environment is still up and running: https://cymbal-bank.fsi.cymbal.dev
 
 ## Update the ledgermonolith bucket
 

--- a/extras/tls-domain-managedcerts/managed-certificates.yaml
+++ b/extras/tls-domain-managedcerts/managed-certificates.yaml
@@ -18,7 +18,7 @@ metadata:
   name: bank-ssl-certificate
 spec:
   domains:
-    - bank-of-anthos.xyz  # repace me with DNS name mapped to bank-address
+    - cymbal-bank.fsi.cymbal.dev  # repace me with DNS name mapped to bank-address
 ---
 apiVersion: v1
 kind: Service

--- a/src/frontend/k8s/overlays/production/managed-certificate.yaml
+++ b/src/frontend/k8s/overlays/production/managed-certificate.yaml
@@ -17,4 +17,4 @@ metadata:
   name: bank-of-anthos-cert
 spec:
   domains:
-    - bank-of-anthos.xyz
+    - cymbal-bank.fsi.cymbal.dev


### PR DESCRIPTION
This PR changes the live demo URL from `bank-of-anthos.xyz` to `cymbal-bank.fsi.cymbal.dev`.