### PR TITLE
Set the spring.jpa.database-platform to provide better log messages

### DIFF
--- a/src/ledger/balancereader/src/main/resources/application.properties
+++ b/src/ledger/balancereader/src/main/resources/application.properties
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 server.port = ${PORT}
 handlers = java.util.logging.ConsoleHandler
 spring.main.banner-mode=off
@@ -11,3 +25,5 @@ spring.sleuth.log.slf4j.enabled=false
 server.tomcat.mbeanregistry.enabled=true
 #enables jpa metrics to be recorded
 spring.jpa.properties.hibernate.generate_statistics=true
+#set the jpa database platform
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/ledger/ledgerwriter/src/main/resources/application.properties
+++ b/src/ledger/ledgerwriter/src/main/resources/application.properties
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 server.port = ${PORT}
 handlers = java.util.logging.ConsoleHandler
 spring.main.banner-mode=off
@@ -11,3 +25,5 @@ spring.sleuth.log.slf4j.enabled=false
 server.tomcat.mbeanregistry.enabled=true
 #enables jpa metrics to be recorded
 spring.jpa.properties.hibernate.generate_statistics=true
+#set the jpa database platform
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/ledger/transactionhistory/src/main/resources/application.properties
+++ b/src/ledger/transactionhistory/src/main/resources/application.properties
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 server.port = ${PORT}
 handlers = java.util.logging.ConsoleHandler
 spring.main.banner-mode=off
@@ -11,3 +25,5 @@ spring.sleuth.log.slf4j.enabled=false
 server.tomcat.mbeanregistry.enabled=true
 #enables jpa metrics to be recorded
 spring.jpa.properties.hibernate.generate_statistics=true
+#set the jpa database platform
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
### Background 
Log messages for DB related issues are not very helpful, an example:

```
buildNativeEntityManagerFactory | Failed to initialize JPA EntityManagerFactory: Unable to create requested service [org.hibernate.engine.jdbc.env.spi.JdbcEnvironment] due to: Unable to determine Dialect without JDBC metadata (please set 'jakarta.persistence.jdbc.url' for common cases or 'hibernate.dialect' when a custom Dialect implementation must be provided)
refresh | Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: Unable to create requested service [org.hibernate.engine.jdbc.env.spi.JdbcEnvironment] due to: Unable to determine Dialect without JDBC metadata (please set 'jakarta.persistence.jdbc.url' for common cases or 'hibernate.dialect' when a custom Dialect implementation must be provided)
```

### Change Summary
Setting the `spring.jpa.database-platform` provides more useful log messages.

```
Caused by: org.springframework.orm.jpa.JpaSystemException: Unable to acquire JDBC Connection [FATAL: password authentication failed for user "admin"] [n/a]
```

### Testing Procedure
Tested locally with skaffold and in my clusters