### PR TITLE
Added Production FWI profiles

### DIFF
--- a/docs/fleet-workload-identity.md
+++ b/docs/fleet-workload-identity.md
@@ -1,0 +1,146 @@
+# Setup for Fleet Workload Identity
+
+[fleet Workload Identity](https://cloud.google.com/anthos/fleet-management/docs/use-workload-identity)
+
+Must use skaffold
+
+# Local
+
+Not yet implemented
+
+# Development
+
+Not yet implemented
+
+# Staging
+
+Not yet implemented
+
+# Production
+
+- Set the required environment variables
+
+  ```
+  PROD_PROJECT_ID="<your project ID>"
+  PROD_FWI_WORKLOAD_IDENTITY_POOL="${PROJECT_ID}.svc.id.goog"
+
+  CLUSTER_MEMBERSHIP_NAME="cluster-prod"
+  PROD_FWI_PROVIDER="https://gkehub.googleapis.com/projects/${PROD_PROJECT_ID}/locations/global/memberships/${CLUSTER_MEMBERSHIP_NAME}"
+
+  PROD_GOOGLE_CLOUD_BACKEND_SERVICE_ACCOUNT="backend@${PROD_PROJECT_ID}.iam.gserviceaccount.com"
+  PROD_K8S_BACKEND_SERVICE_ACCOUNT="backend"
+  PROD_GOOGLE_CLOUD_FRONTEND_SERVICE_ACCOUNT="backend@${PROD_PROJECT_ID}.iam.gserviceaccount.com"
+  PROD_K8S_FRONTEND_SERVICE_ACCOUNT="frontend"
+
+  PROD_K8S_NAMESPACE="cymbal-bank"
+  PROD_ACCOUNT_DB_DATABASE_NAME="account-db"
+  PROD_ACCOUNT_DB_USERNAME="admin"
+  PROD_ACCOUNT_DB_PASSWORD="admin"
+  PROD_LEDGER_DB_DATABASE_NAME="account-db"
+  PROD_LEDGER_DB_USERNAME="admin"
+  PROD_LEDGER_DB_PASSWORD="admin"
+  ```
+
+- Prepare the manifest files
+
+  ```
+  echo "Configure the Kubernetes namespace" && \
+  git restore src/components/production/kustomization.yaml && \
+  sed -i "s/namespace: bank-of-anthos-production/namespace: ${PROD_K8S_NAMESPACE}/" src/components/production/kustomization.yaml
+  ```
+
+  ```
+  echo "Configure the Kubernetes service accounts" && \
+  git restore src/components/backend/kustomization.yaml && \
+  sed -i "s/value: bank-of-anthos/value: ${PROD_K8S_BACKEND_SERVICE_ACCOUNT}/" src/components/backend/kustomization.yaml  && \
+  git restore src/components/bank-of-anthos/kustomization.yaml && \
+  sed -i "s/value: bank-of-anthos/value: ${PROD_K8S_BACKEND_SERVICE_ACCOUNT}/" src/components/bank-of-anthos/kustomization.yaml && \
+  git restore src/components/frontend/kustomization.yaml && \
+  sed -i "s/value: bank-of-anthos/value: ${PROD_K8S_FRONTEND_SERVICE_ACCOUNT}/" src/components/frontend/kustomization.yaml
+  ```
+
+  ```
+  echo "Configure the account-db settings" && \
+  git restore src/accounts/accounts-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)ACCOUNTS_DB_URI:.*$|\1ACCOUNTS_DB_URI: postgresql://${PROD_ACCOUNT_DB_USERNAME}:${PROD_ACCOUNT_DB_PASSWORD}@127.0.0.1:5432/${PROD_ACCOUNT_DB_DATABASE_NAME}|' src/accounts/accounts-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_DB:.*$|\1POSTGRES_DB: ${PROD_ACCOUNT_DB_DATABASE_NAME}|' src/accounts/accounts-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_PASSWORD:.*$|\1POSTGRES_PASSWORD: ${PROD_ACCOUNT_DB_PASSWORD}|' src/accounts/accounts-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_USER:.*$|\1POSTGRES_USER: ${PROD_ACCOUNT_DB_USERNAME}|' src/accounts/accounts-db/k8s/base/config.yaml && \
+  git restore src/components/cloud-sql/accounts-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)ACCOUNTS_DB_URI:.*$|\1ACCOUNTS_DB_URI: postgresql://${PROD_ACCOUNT_DB_USERNAME}:${PROD_ACCOUNT_DB_PASSWORD}@127.0.0.1:5432/${PROD_ACCOUNT_DB_DATABASE_NAME}|' src/components/cloud-sql/accounts-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_DB:.*$|\1POSTGRES_DB: ${PROD_ACCOUNT_DB_DATABASE_NAME}|' src/components/cloud-sql/accounts-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_PASSWORD:.*$|\1POSTGRES_PASSWORD: ${PROD_ACCOUNT_DB_PASSWORD}|' src/components/cloud-sql/accounts-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_USER:.*$|\1POSTGRES_USER: ${PROD_ACCOUNT_DB_USERNAME}|' src/components/cloud-sql/accounts-db.yaml
+  ```
+
+  ```
+  echo "Configure the ledger-db settings" && \
+  git restore src/ledger/ledger-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_DB:.*$|\1POSTGRES_DB: ${PROD_LEDGER_DB_DATABASE_NAME}|' src/ledger/ledger-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_PASSWORD:.*$|\1POSTGRES_PASSWORD: ${PROD_LEDGER_DB_PASSWORD}|' src/ledger/ledger-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_USER:.*$|\1POSTGRES_USER: ${PROD_LEDGER_DB_USERNAME}|' src/ledger/ledger-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)SPRING_DATASOURCE_PASSWORD:.*$|\1SPRING_DATASOURCE_PASSWORD: ${PROD_LEDGER_DB_PASSWORD}|' src/ledger/ledger-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)SPRING_DATASOURCE_URL:.*$|\1SPRING_DATASOURCE_URL: jdbc:postgresql://127.0.0.1:5432/${PROD_LEDGER_DB_DATABASE_NAME}|' src/ledger/ledger-db/k8s/base/config.yaml && \
+  sed -i 's|^\([[:blank:]]*\)SPRING_DATASOURCE_USERNAME:.*$|\1SPRING_DATASOURCE_USERNAME: ${PROD_LEDGER_DB_USERNAME}|' src/ledger/ledger-db/k8s/base/config.yaml && \
+  git restore src/components/cloud-sql/ledger-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_DB:.*$|\1POSTGRES_DB: ${PROD_LEDGER_DB_DATABASE_NAME}|' src/components/cloud-sql/ledger-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_PASSWORD:.*$|\1POSTGRES_PASSWORD: ${PROD_LEDGER_DB_PASSWORD}|' src/components/cloud-sql/ledger-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)POSTGRES_USER:.*$|\1POSTGRES_USER: ${PROD_LEDGER_DB_USERNAME}|' src/components/cloud-sql/ledger-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)SPRING_DATASOURCE_PASSWORD:.*$|\1SPRING_DATASOURCE_PASSWORD: ${google_sql_user.cloud_sql_admin_user.password}|' src/components/cloud-sql/ledger-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)SPRING_DATASOURCE_URL:.*$|\1SPRING_DATASOURCE_URL: jdbc:postgresql://127.0.0.1:5432/${PROD_LEDGER_DB_DATABASE_NAME}|' src/components/cloud-sql/ledger-db.yaml && \
+  sed -i 's|^\([[:blank:]]*\)SPRING_DATASOURCE_USERNAME:.*$|\1SPRING_DATASOURCE_USERNAME: ${PROD_LEDGER_DB_USERNAME}|' src/components/cloud-sql/ledger-db.yaml
+  ```
+
+  ```
+  echo "Configure FWI audience" && \
+  git restore src/components/backend-fwi/add-fwi.yaml && \
+  sed -i 's|audience: FWI_WORKLOAD_IDENTITY_POOL|audience: ${PROD_FWI_WORKLOAD_IDENTITY_POOL}|' src/components/backend-fwi/add-fwi.yaml && \
+  git restore src/components/cloud-sql-fwi/add-fwi.yaml && \
+  sed -i 's|audience: FWI_WORKLOAD_IDENTITY_POOL|audience: ${PROD_FWI_WORKLOAD_IDENTITY_POOL}|' src/components/cloud-sql-fwi/add-fwi.yaml && \
+  git restore src/components/frontend-fwi/add-fwi.yaml && \
+  sed -i 's|audience: FWI_WORKLOAD_IDENTITY_POOL|audience: ${PROD_FWI_WORKLOAD_IDENTITY_POOL}|' src/components/frontend-fwi/add-fwi.yaml
+  ```
+
+- Create the Kubernetes configmaps
+
+  ```
+  cat <<EOT > backend-adc.json
+  {
+      "audience": "identitynamespace:${PROD_FWI_WORKLOAD_IDENTITY_POOL}:${PROD_FWI_PROVIDER}",
+      "credential_source": {
+          "file": "/var/run/secrets/tokens/gcp-ksa/token"
+      },
+      "project_id": "${PROD_PROJECT_ID}",
+      "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${PROD_GOOGLE_CLOUD_BACKEND_SERVICE_ACCOUNT}:generateAccessToken",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "type": "external_account"
+  }
+  EOT && \
+  kubectl create --namespace=${PROD_K8S_NAMESPACE} configmap backend-adc --from-file=backend-adc.json
+  ```
+
+  ```
+  cat <<EOT > frontend-adc.json
+  {
+      "audience": "identitynamespace:${PROD_FWI_WORKLOAD_IDENTITY_POOL}:${PROD_FWI_PROVIDER}",
+      "credential_source": {
+          "file": "/var/run/secrets/tokens/gcp-ksa/token"
+      },
+      "project_id": "${PROD_PROJECT_ID}",
+      "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${PROD_GOOGLE_CLOUD_FRONTEND_SERVICE_ACCOUNT}:generateAccessToken",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "type": "external_account"
+  }
+  EOT && \
+  kubectl create --namespace=${PROD_K8S_NAMESPACE} configmap frontend-adc --from-file=frontend-adc.json
+  ```
+
+- Deploy the application
+
+  ```
+  skaffold run \
+  --profile production,production-fwi \
+  --skip-tests=true
+  ```

--- a/src/accounts/accounts-db/k8s/overlays/init-db-production-fwi/kustomization.yaml
+++ b/src/accounts/accounts-db/k8s/overlays/init-db-production-fwi/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../components/init-db-job
+  - ../../../../../components/cloud-sql-fwi
+  - ../../../../../components/backend
+  - ../../../../../components/production

--- a/src/accounts/accounts-db/k8s/overlays/production-fwi/kustomization.yaml
+++ b/src/accounts/accounts-db/k8s/overlays/production-fwi/kustomization.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../../components/production

--- a/src/accounts/accounts-db/skaffold.yaml
+++ b/src/accounts/accounts-db/skaffold.yaml
@@ -43,6 +43,11 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/production
+- name: production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/production-fwi
 - name: init-db-staging
   manifests:
     kustomize:
@@ -53,3 +58,8 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/init-db-production
+- name: init-db-production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/init-db-production-fwi

--- a/src/accounts/contacts/k8s/overlays/production-fwi/kustomization.yaml
+++ b/src/accounts/contacts/k8s/overlays/production-fwi/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../../components/production
+  - ../../../../../components/backend-fwi
+  - ../../../../../components/cloud-sql-fwi

--- a/src/accounts/contacts/skaffold.yaml
+++ b/src/accounts/contacts/skaffold.yaml
@@ -86,3 +86,8 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/production
+- name: production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/production-fwi

--- a/src/accounts/userservice/k8s/overlays/production-fwi/kustomization.yaml
+++ b/src/accounts/userservice/k8s/overlays/production-fwi/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../../components/production
+  - ../../../../../components/backend-fwi
+  - ../../../../../components/cloud-sql-fwi

--- a/src/accounts/userservice/skaffold.yaml
+++ b/src/accounts/userservice/skaffold.yaml
@@ -86,3 +86,8 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/production
+- name: production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/production-fwi

--- a/src/components/backend-fwi/add-fwi.yaml
+++ b/src/components/backend-fwi/add-fwi.yaml
@@ -1,0 +1,42 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value: 
+    name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /var/run/secrets/tokens/gcp-ksa/google-application-credentials.json
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: gcp-ksa
+    mountPath: /var/run/secrets/tokens/gcp-ksa
+    readOnly: true
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: 
+    name: gcp-ksa
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          path: token
+          audience: FWI_WORKLOAD_IDENTITY_POOL
+          expirationSeconds: 172800
+      - configMap:
+          name: backend-adc
+          optional: false
+          items:
+            - key: "config"
+              path: "google-application-credentials.json"

--- a/src/components/backend-fwi/kustomization.yaml
+++ b/src/components/backend-fwi/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+commonLabels:
+  google-identity: fwi
+patches:
+- path: add-fwi.yaml
+  target:
+    kind: Deployment

--- a/src/components/backend/kustomization.yaml
+++ b/src/components/backend/kustomization.yaml
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+commonLabels:
+  application: bank-of-anthos
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/serviceAccountName
+        value: bank-of-anthos
+  - target:
+      kind: Job
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/serviceAccountName
+        value: bank-of-anthos
+  - target:
+      kind: StatefulSet
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/serviceAccount
+        value: bank-of-anthos

--- a/src/components/cloud-sql-fwi/add-fwi.yaml
+++ b/src/components/cloud-sql-fwi/add-fwi.yaml
@@ -1,0 +1,44 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Deployment
+metadata:
+  name: ignored-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-sql-proxy
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/tokens/gcp-ksa/google-application-credentials.json
+        volumeMounts:
+        - name: gcp-ksa
+          mountPath: /var/run/secrets/tokens/gcp-ksa
+          readOnly: true
+      volumes:
+        - name: gcp-ksa
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: FWI_WORKLOAD_IDENTITY_POOL
+                expirationSeconds: 172800
+            - configMap:
+                name: backend-adc
+                optional: false
+                items:
+                  - key: "config"
+                    path: "google-application-credentials.json"

--- a/src/components/cloud-sql-fwi/kustomization.yaml
+++ b/src/components/cloud-sql-fwi/kustomization.yaml
@@ -1,0 +1,27 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+commonLabels:
+  google-identity: fwi
+components:
+  - ../cloud-sql
+patches:
+- path: add-fwi.yaml
+  target:
+    kind: Deployment
+- path: add-fwi.yaml
+  target:
+    kind: Job

--- a/src/components/frontend-fwi/add-fwi.yaml
+++ b/src/components/frontend-fwi/add-fwi.yaml
@@ -1,0 +1,42 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value: 
+    name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /var/run/secrets/tokens/gcp-ksa/google-application-credentials.json
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: gcp-ksa
+    mountPath: /var/run/secrets/tokens/gcp-ksa
+    readOnly: true
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: 
+    name: gcp-ksa
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          path: token
+          audience: FWI_WORKLOAD_IDENTITY_POOL
+          expirationSeconds: 172800
+      - configMap:
+          name: frontend-adc
+          optional: false
+          items:
+            - key: "config"
+              path: "google-application-credentials.json"

--- a/src/components/frontend-fwi/kustomization.yaml
+++ b/src/components/frontend-fwi/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+commonLabels:
+  google-identity: fwi
+patches:
+- path: add-fwi.yaml
+  target:
+    kind: Deployment

--- a/src/components/frontend/kustomization.yaml
+++ b/src/components/frontend/kustomization.yaml
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+commonLabels:
+  application: bank-of-anthos
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/serviceAccountName
+        value: bank-of-anthos

--- a/src/components/service-cluster-ip/kustomization.yaml
+++ b/src/components/service-cluster-ip/kustomization.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+- path: set-type-cluster-ip.yaml
+  target:
+    kind: Service

--- a/src/components/service-cluster-ip/set-type-cluster-ip.yaml
+++ b/src/components/service-cluster-ip/set-type-cluster-ip.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ignored-by-kustomize
+spec:
+  type: ClusterIP

--- a/src/frontend/k8s/overlays/production-fwi-ingress/frontend-ingress.yaml
+++ b/src/frontend/k8s/overlays/production-fwi-ingress/frontend-ingress.yaml
@@ -1,0 +1,29 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              number: 80

--- a/src/frontend/k8s/overlays/production-fwi-ingress/kustomization.yaml
+++ b/src/frontend/k8s/overlays/production-fwi-ingress/kustomization.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - frontend-ingress.yaml
+components:
+  - ../../../../components/production
+  - ../../../../components/frontend
+  - ../../../../components/frontend-fwi
+  - ../../../../components/service-cluster-ip

--- a/src/frontend/k8s/overlays/production-fwi/kustomization.yaml
+++ b/src/frontend/k8s/overlays/production-fwi/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../components/production
+  - ../../../../components/frontend
+  - ../../../../components/frontend-fwi

--- a/src/frontend/skaffold.yaml
+++ b/src/frontend/skaffold.yaml
@@ -62,3 +62,13 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/production
+- name: production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/production-fwi
+- name: production-fwi-ingress
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/production-fwi-ingress

--- a/src/ledger/balancereader/k8s/overlays/production-fwi/kustomization.yaml
+++ b/src/ledger/balancereader/k8s/overlays/production-fwi/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../../components/production
+  - ../../../../../components/backend-fwi
+  - ../../../../../components/cloud-sql-fwi

--- a/src/ledger/balancereader/skaffold.yaml
+++ b/src/ledger/balancereader/skaffold.yaml
@@ -75,3 +75,8 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/production
+- name: production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/production-fwi

--- a/src/ledger/ledger-db/k8s/overlays/init-db-production-fwi/kustomization.yaml
+++ b/src/ledger/ledger-db/k8s/overlays/init-db-production-fwi/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../components/init-db-job
+  - ../../../../../components/cloud-sql-fwi
+  - ../../../../../components/backend
+  - ../../../../../components/production

--- a/src/ledger/ledger-db/k8s/overlays/production-fwi/kustomization.yaml
+++ b/src/ledger/ledger-db/k8s/overlays/production-fwi/kustomization.yaml
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../../components/production
+  - ../../../../../components/cloud-sql-fwi

--- a/src/ledger/ledger-db/skaffold.yaml
+++ b/src/ledger/ledger-db/skaffold.yaml
@@ -43,6 +43,11 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/production
+- name: production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/production-fwi
 - name: init-db-staging
   manifests:
     kustomize:
@@ -53,3 +58,8 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/init-db-production
+- name: init-db-production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/init-db-production-fwi

--- a/src/ledger/ledgerwriter/k8s/overlays/production-fwi/kustomization.yaml
+++ b/src/ledger/ledgerwriter/k8s/overlays/production-fwi/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../../components/production
+  - ../../../../../components/backend-fwi
+  - ../../../../../components/cloud-sql-fwi

--- a/src/ledger/ledgerwriter/skaffold.yaml
+++ b/src/ledger/ledgerwriter/skaffold.yaml
@@ -75,3 +75,8 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/production
+- name: production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/production-fwi

--- a/src/ledger/transactionhistory/k8s/overlays/production-fwi/kustomization.yaml
+++ b/src/ledger/transactionhistory/k8s/overlays/production-fwi/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../../components/production
+  - ../../../../../components/backend-fwi
+  - ../../../../../components/cloud-sql-fwi

--- a/src/ledger/transactionhistory/skaffold.yaml
+++ b/src/ledger/transactionhistory/skaffold.yaml
@@ -75,3 +75,8 @@ profiles:
     kustomize:
       paths:
       - k8s/overlays/production
+- name: production-fwi
+  manifests:
+    kustomize:
+      paths:
+      - k8s/overlays/production-fwi


### PR DESCRIPTION
### Background 
The current skaffold did not have support for using fleet workload identity with the application for "not on GCP" deployments. 

### Change Summary
Added a `production-fwi` skaffold profile to deploy the application using fleet workload identity. 

### Testing Procedure
Tested using the [GDC-V Reference Architecture Terraform](https://github.com/GoogleCloudPlatform/gdcv-bare-metal-ref-arch/blob/terraform/docs/terraform/deploy-to-gce-instances-manual-lb.md)