### PR TITLE
removing reference to obsolete sample deployment marketplace app

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ The following button opens up an interactive tutorial showing how to deploy Bank
 - [Troubleshooting](/docs/troubleshooting.md) to learn how to resolve common problems.
 
 ## Demos featuring Bank of Anthos
-- [Tutorial: Explore Anthos (Google Cloud docs)](https://cloud.google.com/anthos/docs/tutorials/explore-anthos)
 - [Tutorial: Migrating a monolith VM to GKE](https://cloud.google.com/migrate/containers/docs/migrating-monolith-vm-overview-setup)
 - [Tutorial: Running distributed services on GKE private clusters using ASM](https://cloud.google.com/service-mesh/docs/distributed-services-private-clusters)
 - [Tutorial: Run full-stack workloads at scale on GKE](https://cloud.google.com/kubernetes-engine/docs/tutorials/full-stack-scale)


### PR DESCRIPTION
### Fixes #2043

### Background 
noticed the sample has a link to a marketplace app we're trying to remove. just wanted to delete the link.

### Change Summary
just a link removal from the root readme.

### Additional Notes
n/a

### Testing Procedure
however the main readme is checked, this is not a major change.

### Related PRs or Issues 
