### PR TITLE
Disabled spring.cloud.gcp.trace to stop ADC lookup

### DIFF
--- a/src/ledger/balancereader/src/main/resources/application.properties
+++ b/src/ledger/balancereader/src/main/resources/application.properties
@@ -17,6 +17,7 @@ handlers = java.util.logging.ConsoleHandler
 spring.main.banner-mode=off
 # tracing on/off toggle
 spring.sleuth.enabled = ${ENABLE_TRACING}
+spring.cloud.gcp.trace.enabled=${ENABLE_TRACING}
 # if tracing enabled, configuration options:
 spring.sleuth.sampler.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)

--- a/src/ledger/ledgerwriter/src/main/resources/application.properties
+++ b/src/ledger/ledgerwriter/src/main/resources/application.properties
@@ -17,6 +17,7 @@ handlers = java.util.logging.ConsoleHandler
 spring.main.banner-mode=off
 # tracing on/off toggle
 spring.sleuth.enabled = ${ENABLE_TRACING}
+spring.cloud.gcp.trace.enabled=${ENABLE_TRACING}
 # if tracing enabled, configuration options:
 spring.sleuth.sampler.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)

--- a/src/ledger/transactionhistory/src/main/resources/application.properties
+++ b/src/ledger/transactionhistory/src/main/resources/application.properties
@@ -17,6 +17,7 @@ handlers = java.util.logging.ConsoleHandler
 spring.main.banner-mode=off
 # tracing on/off toggle
 spring.sleuth.enabled = ${ENABLE_TRACING}
+spring.cloud.gcp.trace.enabled=${ENABLE_TRACING}
 # if tracing enabled, configuration options:
 spring.sleuth.sampler.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)


### PR DESCRIPTION
### Fixes https://github.com/GoogleCloudPlatform/bank-of-anthos/issues/1998

### Background 
Even with `spring.sleuth.enabled` set to `false`, zipkin2 tried to lookup the ADC credentials. This causes the application to crash on some environments. 

### Change Summary
Added `spring.cloud.gcp.trace.enabled`  to be set via the `ENABLE_TRACING` environment variable as well to fully disable the trace functionality in the apps.

### Testing Procedure
Tested on my personal machine using Docker Desktop.