### PR TITLE
fix: Pin postgresql module to known good version

### DIFF
--- a/iac/tf-multienv-cicd-anthos-autopilot/env-production.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/env-production.tf
@@ -73,9 +73,10 @@ resource "google_service_account_iam_member" "gke_workload_production_identity" 
   ]
 }
 
-# CloudSQL Postgres production instance 
+# CloudSQL Postgres production instance
 module "cloudsql_production" {
-  source = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
+  source  = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
+  version = "~> 20.0.0"
 
   project_id = var.project_id
   region     = var.region

--- a/iac/tf-multienv-cicd-anthos-autopilot/env-staging.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/env-staging.tf
@@ -73,9 +73,10 @@ resource "google_service_account_iam_member" "gke_workload_staging_identity" {
   ]
 }
 
-# CloudSQL Postgres staging instance 
+# CloudSQL Postgres staging instance
 module "cloudsql_staging" {
-  source = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
+  source  = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
+  version = "~> 20.0.0"
 
   project_id = var.project_id
   region     = var.region


### PR DESCRIPTION
### Fixes #2184

### Background 
An [issue](https://github.com/terraform-google-modules/terraform-google-sql-db/issues/624) in the unpinned [postgresql](https://github.com/terraform-google-modules/terraform-google-sql-db/tree/master/modules/postgresql) module was causing Terraform to fail to run.

### Change Summary
- Pin to a known good version (v20)
- Trivial trailing whitespace fix