### PR TITLE
fix: Ensure application files are readable by non-root users

### DIFF
--- a/src/accounts/contacts/Dockerfile
+++ b/src/accounts/contacts/Dockerfile
@@ -37,4 +37,7 @@ ENV LOG_LEVEL info
 # Add application code.
 COPY . .
 
+# Ensure files are readable for non-root users
+RUN chmod a+r *
+
 CMD gunicorn -b :$PORT --threads 4 --log-config logging.conf --log-level=$LOG_LEVEL "contacts:create_app()"

--- a/src/accounts/userservice/Dockerfile
+++ b/src/accounts/userservice/Dockerfile
@@ -37,5 +37,8 @@ ENV LOG_LEVEL info
 # Add application code.
 COPY . .
 
+# Ensure files are readable for non-root users
+RUN chmod a+r *
+
 # Start server using gunicorn
 CMD gunicorn -b :$PORT --threads 2 --log-config logging.conf --log-level=$LOG_LEVEL "userservice:create_app()"

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -37,5 +37,8 @@ ENV LOG_LEVEL info
 # Add application code.
 COPY . .
 
+# Ensure files are readable for non-root users
+RUN find . -type f -name '*' -exec chmod a+r '{}' ';'
+
 # Start server using gunicorn
 CMD gunicorn -b :$PORT --threads 4 --log-config logging.conf --log-level=$LOG_LEVEL "frontend:create_app()"


### PR DESCRIPTION
### Fixes #2193 

### Background 
The following services were failing to start (state of `CrashLoopBackOff`), because of missing file permissions in `/app` for non-root users:

- `contacts`
- `userservice`
- `frontend`

### Change Summary
Update Dockerfile to modify permissions of files in `/app` so they are readable by all users.

### Related PRs or Issues 
#2193 