### PR TITLE
fix: Pin Google Terraform providers to known good version

### DIFF
--- a/iac/tf-multienv-cicd-anthos-autopilot/main.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/main.tf
@@ -19,10 +19,12 @@ terraform {
   }
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
+      version = "~> 5.40.0"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
+      version = "~> 5.40.0"
     }
   }
 }


### PR DESCRIPTION
### Fixes #2200

### Background 
With recent versions of the Google Terraform providers, Config Sync was not being enabled in clusters for the `tf-multienv-cicd-anthos-autopilot` deployment, causing clusters to fail to sync.

### Change Summary
Pin the providers to a tested and known good version, pending further investigation into the provider changes.

###
Fixes #2200.
