### PR TITLE
Bump Terraform provider and update config accordingly

### DIFF
--- a/iac/tf-multienv-cicd-anthos-autopilot/artifact-registry.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/artifact-registry.tf
@@ -20,8 +20,6 @@ resource "google_artifact_registry_repository" "container_registry" {
   description   = "Bank of Anthos docker repository"
   project       = var.project_id
 
-  provider = google-beta
-
   depends_on = [
     module.enabled_google_apis
   ]

--- a/iac/tf-multienv-cicd-anthos-autopilot/env-development.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/env-development.tf
@@ -44,6 +44,7 @@ module "gke_development" {
   enable_vertical_pod_autoscaling = true
   horizontal_pod_autoscaling      = true
   create_service_account          = false # currently not supported by terraform for autopilot clusters
+  deletion_protection             = false
   cluster_resource_labels         = { "mesh_id" : "proj-${data.google_project.project.number}" }
 
   providers = {
@@ -85,7 +86,6 @@ resource "google_service_account_iam_member" "gke_workload_development_admin" {
 
 # create fleet membership for development GKE cluster
 resource "google_gke_hub_membership" "development" {
-  provider      = google-beta
   project       = var.project_id
   membership_id = "development-membership"
   endpoint {
@@ -108,7 +108,6 @@ resource "google_gke_hub_feature_membership" "asm_development" {
   mesh {
     management = "MANAGEMENT_AUTOMATIC"
   }
-  provider = google-beta
 }
 
 
@@ -121,6 +120,7 @@ resource "google_gke_hub_feature_membership" "acm_development" {
   membership = google_gke_hub_membership.development.membership_id
   configmanagement {
     config_sync {
+      enabled = true
       git {
         sync_repo   = local.sync_repo_url
         sync_branch = var.sync_branch
@@ -130,6 +130,4 @@ resource "google_gke_hub_feature_membership" "acm_development" {
       source_format = "unstructured"
     }
   }
-  provider = google-beta
 }
-

--- a/iac/tf-multienv-cicd-anthos-autopilot/env-production.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/env-production.tf
@@ -44,6 +44,7 @@ module "gke_production" {
   enable_vertical_pod_autoscaling = true
   horizontal_pod_autoscaling      = true
   create_service_account          = false # currently not supported by terraform for autopilot clusters
+  deletion_protection             = false
   cluster_resource_labels         = { "mesh_id" : "proj-${data.google_project.project.number}" }
 
   providers = {
@@ -107,7 +108,6 @@ module "cloudsql_production" {
 
 # create fleet membership for production GKE cluster
 resource "google_gke_hub_membership" "production" {
-  provider      = google-beta
   project       = var.project_id
   membership_id = "production-membership"
   endpoint {
@@ -130,7 +130,6 @@ resource "google_gke_hub_feature_membership" "asm_production" {
   mesh {
     management = "MANAGEMENT_AUTOMATIC"
   }
-  provider = google-beta
 }
 
 # configure ACM for production GKE cluster
@@ -142,6 +141,7 @@ resource "google_gke_hub_feature_membership" "acm_production" {
   membership = google_gke_hub_membership.production.membership_id
   configmanagement {
     config_sync {
+      enabled = true
       git {
         sync_repo   = local.sync_repo_url
         sync_branch = var.sync_branch
@@ -151,7 +151,6 @@ resource "google_gke_hub_feature_membership" "acm_production" {
       source_format = "unstructured"
     }
   }
-  provider = google-beta
 }
 
 resource "google_compute_global_address" "production_ip" {

--- a/iac/tf-multienv-cicd-anthos-autopilot/env-staging.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/env-staging.tf
@@ -44,6 +44,7 @@ module "gke_staging" {
   enable_vertical_pod_autoscaling = true
   horizontal_pod_autoscaling      = true
   create_service_account          = false # currently not supported by terraform for autopilot clusters
+  deletion_protection             = false
   cluster_resource_labels         = { "mesh_id" : "proj-${data.google_project.project.number}" }
 
   providers = {
@@ -107,7 +108,6 @@ module "cloudsql_staging" {
 
 # create fleet membership for staging GKE cluster
 resource "google_gke_hub_membership" "staging" {
-  provider      = google-beta
   project       = var.project_id
   membership_id = "staging-membership"
   endpoint {
@@ -130,7 +130,6 @@ resource "google_gke_hub_feature_membership" "asm_staging" {
   mesh {
     management = "MANAGEMENT_AUTOMATIC"
   }
-  provider = google-beta
 }
 
 # configure ACM for staging GKE cluster
@@ -142,6 +141,7 @@ resource "google_gke_hub_feature_membership" "acm_staging" {
   membership = google_gke_hub_membership.staging.membership_id
   configmanagement {
     config_sync {
+      enabled = true
       git {
         sync_repo   = local.sync_repo_url
         sync_branch = var.sync_branch
@@ -151,5 +151,4 @@ resource "google_gke_hub_feature_membership" "acm_staging" {
       source_format = "unstructured"
     }
   }
-  provider = google-beta
 }

--- a/iac/tf-multienv-cicd-anthos-autopilot/fleet-features.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/fleet-features.tf
@@ -17,8 +17,6 @@ resource "google_gke_hub_feature" "asm" {
   name = "servicemesh"
   location = "global"
   project = var.project_id
-  
-  provider = google-beta
 
   depends_on = [
     module.enabled_google_apis
@@ -30,8 +28,6 @@ resource "google_gke_hub_feature" "acm" {
   name = "configmanagement"
   location = "global"
   project = var.project_id
-  
-  provider = google-beta
 
   depends_on = [
     module.enabled_google_apis

--- a/iac/tf-multienv-cicd-anthos-autopilot/main.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/main.tf
@@ -20,16 +20,16 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.40.0"
+      version = "~> 5.43.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.40.0"
+      version = "~> 5.43.0"
     }
   }
 }
 
-# google-beta provider for fleet API, artifact registry
+# google-beta provider retained for version pinning
 provider "google-beta" {
   project = var.project_id
   region  = var.region

--- a/iac/tf-multienv-cicd-anthos-autopilot/modules/ci-cd-pipeline/cloud-deploy.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/modules/ci-cd-pipeline/cloud-deploy.tf
@@ -31,5 +31,4 @@ resource "google_clouddeploy_delivery_pipeline" "delivery-pipeline" {
       }
     }
   }
-  provider = google-beta
 }

--- a/iac/tf-multienv-cicd-anthos-autopilot/modules/ci-cd-pipeline/service-accounts.tf
+++ b/iac/tf-multienv-cicd-anthos-autopilot/modules/ci-cd-pipeline/service-accounts.tf
@@ -27,7 +27,7 @@ resource "google_artifact_registry_repository_iam_member" "cloud_build" {
   role   = "roles/artifactregistry.writer"
   member = "serviceAccount:${google_service_account.cloud_build.email}"
 
-  provider = google-beta
+  depends_on = [ google_service_account.cloud_build ]
 }
 
 resource "google_service_account_iam_member" "cloud_build_impersonate_cloud_deploy" {
@@ -35,4 +35,3 @@ resource "google_service_account_iam_member" "cloud_build_impersonate_cloud_depl
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.cloud_build.email}"
 }
-


### PR DESCRIPTION
### Background 
This bumps the Google Terraform provider to the most recent 5.xx version (as a result of a recent [breaking change](https://github.com/hashicorp/terraform-provider-google/pull/19016)), and additionally includes associated updates to the Terraform config:

- Bring the config into line with the new provider as it relates to Config Sync (i.e. include `enabled = true`)
- Remove direct use of the `google-beta` provider (though it is still used by some dependencies)
- Switch off the now-default [deletion protection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#deletion_protection) for the GKE clusters (for ease of testing)

### Additional Notes
This PR is marked as `draft` until further updates are available on the Config Sync breaking change.