### PR TITLE
Remove gcr.io references in the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ cluster: check-env
 deploy: check-env
 	echo ${CLUSTER}
 	gcloud container clusters get-credentials --project ${PROJECT_ID} ${CLUSTER} --zone ${ZONE}
-	skaffold run --default-repo=gcr.io/${PROJECT_ID} -l skaffold.dev/run-id=${CLUSTER}-${PROJECT_ID}-${ZONE}
+	skaffold run --default-repo=us-central1-docker.pkg.dev/${PROJECT_ID}/bank-of-anthos -l skaffold.dev/run-id=${CLUSTER}-${PROJECT_ID}-${ZONE}
 
 deploy-continuous: check-env
 	gcloud container clusters get-credentials --project ${PROJECT_ID} ${CLUSTER} --zone ${ZONE}
-	skaffold dev --default-repo=gcr.io/${PROJECT_ID}
+	skaffold dev --default-repo=us-central1-docker.pkg.dev/${PROJECT_ID}/bank-of-anthos
 
 monolith-fw-rule: check-env
 	export CLUSTER_POD_CIDR="$(shell gcloud container clusters describe ${CLUSTER} --format="value(clusterIpv4Cidr)" --project ${PROJECT_ID} --zone=${ZONE})" && \

--- a/docs/development.md
+++ b/docs/development.md
@@ -120,7 +120,7 @@ export PROJECT_ID="your project id"
 The [`skaffold dev`](https://skaffold.dev/docs/references/cli/#skaffold-dev) command watches your local code, and continuously builds and deploys container images to your GKE cluster anytime you save a file. Skaffold uses Docker Desktop to build the Python images, then [Jib](https://github.com/GoogleContainerTools/jib#jib) (installed via Maven) to build the Java images. 
 
 ```
-skaffold dev --profile development --default-repo=gcr.io/${PROJECT_ID}/bank-of-anthos
+skaffold dev --profile development --default-repo=us-central1-docker.pkg.dev/${PROJECT_ID}/bank-of-anthos
 ```
 
 Note that you can skip tests by running `skaffold` with `--skip-tests=true`, if needed.
@@ -130,7 +130,7 @@ Note that you can skip tests by running `skaffold` with `--skip-tests=true`, if 
 The [`skaffold run`](https://skaffold.dev/docs/references/cli/#skaffold-run) command build and deploys the services to your GKE cluster one time, then exits. 
 
 ```
-skaffold run --profile development --default-repo=gcr.io/${PROJECT_ID}/bank-of-anthos
+skaffold run --profile development --default-repo=us-central1-docker.pkg.dev/${PROJECT_ID}/bank-of-anthos
 ```
 
 ### Running services selectively
@@ -143,7 +143,7 @@ Skaffold reads the [skaffold.yaml](../skaffold.yaml) file to understand the proj
 
 For example, to work with only the `frontend` module, run:
 ```
-skaffold dev --profile development --default-repo=gcr.io/${PROJECT_ID}/bank-of-anthos --module frontend
+skaffold dev --profile development --default-repo=us-central1-docker.pkg.dev/${PROJECT_ID}/bank-of-anthos --module frontend
 ```
 
 ## Cleaning up your deployment

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,8 +66,8 @@ Events:
   ----     ------       ----               ----                                             -------
   Normal   Scheduled    73s                default-scheduler                                Successfully assigned default/balancereader-fb6784fc-9fw2k to gke-toggles-default-pool-28882412-xljt
   Warning  FailedMount  72s (x2 over 72s)  kubelet, gke-toggles-default-pool-28882412-xljt  MountVolume.SetUp failed for volume "publickey" : secret "jwt-key" not found
-  Normal   Pulling      70s                kubelet, gke-toggles-default-pool-28882412-xljt  Pulling image "gcr.io/my-cool-project/bank-of-anthos/gcr.io/bank-of-anthos-ci/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
-  Normal   Pulled       69s                kubelet, gke-toggles-default-pool-28882412-xljt  Successfully pulled image "gcr.io/my-cool-projectt/bank-of-anthos/gcr.io/bank-of-anthos-ci/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
+  Normal   Pulling      70s                kubelet, gke-toggles-default-pool-28882412-xljt  Pulling image "us-central1-docker.pkg.dev/my-cool-project/bank-of-anthos/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
+  Normal   Pulled       69s                kubelet, gke-toggles-default-pool-28882412-xljt  Successfully pulled image "us-central1-docker.pkg.dev/my-cool-project/bank-of-anthos/balancereader:ver.0-171-gd459ddb-dirty@sha256:5b178bd029d04e25bf68df57096b961a28dfb243717d380524a89de994d81ff6"
   Normal   Created      69s                kubelet, gke-toggles-default-pool-28882412-xljt  Created container balancereader
   Normal   Started      69s                kubelet, gke-toggles-default-pool-28882412-xljt  Started container balancereader
   Warning  Unhealthy    4s (x2 over 9s)    kubelet, gke-toggles-default-pool-28882412-xljt  Readiness probe failed: Get http://10.0.1.141:8080/ready: dial tcp 10.0.1.141:8080: connect: connection refused


### PR DESCRIPTION
This PR removes references to `gcr.io` in the docs.

Release images have all moved to `us-central1-docker.pkg.dev` a long time ago, and that's what the instructions should use too.

The only references left are those of older images in `extras/`, but those images remain accessible. When those extras are updated with newer images they'll use the `us-central1-docker.pkg.dev` tags.