### PR TITLE
Hide checks badge from the README temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bank of Anthos
 
-![GitHub branch check runs](https://img.shields.io/github/check-runs/GoogleCloudPlatform/bank-of-anthos/main)
+<!-- Checks badge below seem to take a "neutral" check as a negative and shows failures if some checks are neutral. Commenting out the badge for now. -->
+<!-- ![GitHub branch check runs](https://img.shields.io/github/check-runs/GoogleCloudPlatform/bank-of-anthos/main) -->
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Fcymbal-bank.fsi.cymbal.dev%2F&label=live%20demo
 )](https://cymbal-bank.fsi.cymbal.dev)
 


### PR DESCRIPTION
Checks badge sees neutral checks as a negative, showing a failure badge instead of a success. Commenting out for now.