### PR TITLE
Fix(issue-2309): Respect GOOGLE_CLOUD_PROJECT in Java services

### DIFF
--- a/kubernetes-manifests/config.yaml
+++ b/kubernetes-manifests/config.yaml
@@ -19,6 +19,10 @@ metadata:
 data:
   LOCAL_ROUTING_NUM: "883745000"
   PUB_KEY_PATH: "/tmp/.ssh/publickey"
+  # Set to target GCP project for metrics/tracing when using cross-project
+  # Workload Identity (e.g. cluster in Project A, SA in Project B).
+  # If unset, the GCE metadata server project is used.
+  # GOOGLE_CLOUD_PROJECT: "your-target-project-id"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,29 @@
+### Fixes #2309
+
+### Background 
+The Java ledger services (`balancereader`, `ledgerwriter`, `transactionhistory`) were resolving their GCP Project ID solely via `MetadataConfig.getProjectId()`, which queries the GCE metadata server. This meant they always used the hosting project's ID, ignoring the `GOOGLE_CLOUD_PROJECT` environment variable. This behavior broke cross-project Workload Identity setups (e.g., GKE cluster in Project A, Service Account/Monitoring in Project B).
+
+### Change Summary
+- **Java Services:** Updated `projectId()` in `BalanceReaderApplication.java`, `LedgerWriterApplication.java`, and `TransactionHistoryApplication.java` to check `System.getenv("GOOGLE_CLOUD_PROJECT")` first. It falls back to the metadata server only if the env var is missing.
+- **Spring Config:** Added `spring.cloud.gcp.project-id=${GOOGLE_CLOUD_PROJECT:}` to `application.properties` for all three services to ensure Spring Cloud GCP tracing also respects the environment variable.
+- **Kubernetes Manifests:** Added a commented-out `GOOGLE_CLOUD_PROJECT` field to the `environment-config` ConfigMap in `config.yaml` to document how to configure this.
+- **Tests:** Added unit tests for `resolveProjectId` logic in all three services.
+
+### Additional Notes
+This change is non-breaking for existing deployments as usage of the `GOOGLE_CLOUD_PROJECT` environment variable is optional. Behavior defaults to the metadata server (existing behavior) if the variable is unset.
+
+### Testing Procedure
+**Automated Testing:**
+- Ran `mvnw test` for all 3 services.
+- **Results:** 53 tests passed, 0 failures.
+
+**Manual Verification (GKE):**
+1. Built custom Jib images for the 3 modified services.
+2. Deployed to a GKE cluster with `GOOGLE_CLOUD_PROJECT` set in the ConfigMap.
+3. **Verification:**
+    - Confirmed `config.yaml` applied the environment variable.
+    - Verified pods started successfully (`Running` status).
+    - Verified metrics and logs were correctly exported to the target GCP project in Cloud Monitoring.
+
+### Related PRs or Issues 
+Fixes #2309

--- a/src/ledger/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
+++ b/src/ledger/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package anthos.samples.bankofanthos.balancereader;
 
 import com.google.cloud.MetadataConfig;

--- a/src/ledger/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
+++ b/src/ledger/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
@@ -38,17 +38,16 @@ import org.springframework.context.annotation.Bean;
 @SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 public class BalanceReaderApplication {
 
-    private static final Logger LOGGER =
-        LogManager.getLogger(BalanceReaderApplication.class);
+    private static final Logger LOGGER = LogManager.getLogger(BalanceReaderApplication.class);
 
     private static final String[] EXPECTED_ENV_VARS = {
-        "VERSION",
-        "PORT",
-        "LOCAL_ROUTING_NUM",
-        "PUB_KEY_PATH",
-        "SPRING_DATASOURCE_URL",
-        "SPRING_DATASOURCE_USERNAME",
-        "SPRING_DATASOURCE_PASSWORD"
+            "VERSION",
+            "PORT",
+            "LOCAL_ROUTING_NUM",
+            "PUB_KEY_PATH",
+            "SPRING_DATASOURCE_URL",
+            "SPRING_DATASOURCE_USERNAME",
+            "SPRING_DATASOURCE_PASSWORD"
     };
 
     public static void main(String[] args) {
@@ -57,14 +56,14 @@ public class BalanceReaderApplication {
             String value = System.getenv(v);
             if (value == null) {
                 LOGGER.fatal(String.format(
-                    "%s environment variable not set", v));
+                        "%s environment variable not set", v));
                 System.exit(1);
             }
         }
         SpringApplication.run(BalanceReaderApplication.class, args);
         LOGGER.log(Level.forName("STARTUP", Level.FATAL.intLevel()),
-            String.format("Started BalanceReader service. Log level is: %s",
-                LOGGER.getLevel().toString()));
+                String.format("Started BalanceReader service. Log level is: %s",
+                        LOGGER.getLevel().toString()));
 
     }
 
@@ -86,29 +85,27 @@ public class BalanceReaderApplication {
                 boolean enableMetricsExport = true;
 
                 if (System.getenv("ENABLE_METRICS") != null
-                    && System.getenv("ENABLE_METRICS").equals("false")) {
+                        && System.getenv("ENABLE_METRICS").equals("false")) {
                     enableMetricsExport = false;
                 }
 
                 LOGGER.info(String.format("Enable metrics export: %b",
-                    enableMetricsExport));
+                        enableMetricsExport));
                 return enableMetricsExport;
             }
 
-
             @Override
             public String projectId() {
-                String id = MetadataConfig.getProjectId();
-                if (id == null) {
-                    id = "";
-                }
-                return id;
+                return resolveProjectId(
+                        System.getenv("GOOGLE_CLOUD_PROJECT"),
+                        MetadataConfig.getProjectId());
             }
 
             @Override
             public String get(String key) {
                 return null;
             }
+
             @Override
             public String resourceType() {
                 return "k8s_container";
@@ -119,7 +116,7 @@ public class BalanceReaderApplication {
                 Map<String, String> map = new HashMap<>();
                 String podName = System.getenv("HOSTNAME");
                 String containerName = podName.substring(0,
-                    podName.indexOf("-"));
+                        podName.indexOf("-"));
                 map.put("location", MetadataConfig.getZone());
                 map.put("container_name", containerName);
                 map.put("pod_name", podName);
@@ -128,5 +125,25 @@ public class BalanceReaderApplication {
                 return map;
             }
         }).build();
+    }
+
+    /**
+     * Resolves the GCP project ID for metrics export.
+     * Prefers the GOOGLE_CLOUD_PROJECT env var over the GCE metadata server
+     * to support cross-project Workload Identity setups (issue #2309).
+     *
+     * @param envProjectId      value of GOOGLE_CLOUD_PROJECT env var (may be null)
+     * @param metadataProjectId value from GCE metadata server (may be null)
+     * @return resolved project ID, or empty string if both are null
+     */
+    static String resolveProjectId(String envProjectId,
+            String metadataProjectId) {
+        if (envProjectId != null && !envProjectId.isEmpty()) {
+            return envProjectId;
+        }
+        if (metadataProjectId != null) {
+            return metadataProjectId;
+        }
+        return "";
     }
 }

--- a/src/ledger/balancereader/src/main/resources/application.properties
+++ b/src/ledger/balancereader/src/main/resources/application.properties
@@ -18,6 +18,8 @@ spring.main.banner-mode=off
 # tracing on/off toggle
 spring.sleuth.enabled = ${ENABLE_TRACING}
 spring.cloud.gcp.trace.enabled=${ENABLE_TRACING}
+# Override GCP project for metrics/tracing (supports cross-project Workload Identity)
+spring.cloud.gcp.project-id=${GOOGLE_CLOUD_PROJECT:}
 # if tracing enabled, configuration options:
 spring.sleuth.sampler.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)

--- a/src/ledger/balancereader/src/test/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplicationTest.java
+++ b/src/ledger/balancereader/src/test/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplicationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020, Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package anthos.samples.bankofanthos.balancereader;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for project ID resolution logic in BalanceReaderApplication.
+ * Verifies fix for issue #2309: GOOGLE_CLOUD_PROJECT env var should
+ * take precedence over the GCE metadata server project.
+ */
+class BalanceReaderApplicationTest {
+
+    @Test
+    @DisplayName("When GOOGLE_CLOUD_PROJECT is set, use it over metadata")
+    void resolveProjectIdPrefersEnvVar() {
+        String result = BalanceReaderApplication.resolveProjectId(
+                "project-b", "project-a");
+        assertEquals("project-b", result);
+    }
+
+    @Test
+    @DisplayName("When GOOGLE_CLOUD_PROJECT is null, fall back to metadata")
+    void resolveProjectIdFallsBackToMetadata() {
+        String result = BalanceReaderApplication.resolveProjectId(
+                null, "project-a");
+        assertEquals("project-a", result);
+    }
+
+    @Test
+    @DisplayName("When GOOGLE_CLOUD_PROJECT is empty, fall back to metadata")
+    void resolveProjectIdFallsBackToMetadataWhenEmpty() {
+        String result = BalanceReaderApplication.resolveProjectId(
+                "", "project-a");
+        assertEquals("project-a", result);
+    }
+
+    @Test
+    @DisplayName("When both are null, return empty string")
+    void resolveProjectIdReturnsEmptyWhenBothNull() {
+        String result = BalanceReaderApplication.resolveProjectId(
+                null, null);
+        assertEquals("", result);
+    }
+
+    @Test
+    @DisplayName("When env var is set and metadata is null, use env var")
+    void resolveProjectIdUsesEnvVarWhenMetadataNull() {
+        String result = BalanceReaderApplication.resolveProjectId(
+                "project-b", null);
+        assertEquals("project-b", result);
+    }
+}

--- a/src/ledger/balancereader/src/test/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplicationTest.java
+++ b/src/ledger/balancereader/src/test/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplicationTest.java
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package anthos.samples.bankofanthos.balancereader;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/ledger/balancereader/src/test/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplicationTest.java
+++ b/src/ledger/balancereader/src/test/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplicationTest.java
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020, Google LLC.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ledger/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
+++ b/src/ledger/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
@@ -39,18 +39,17 @@ import org.springframework.web.client.RestTemplate;
 @SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 public class LedgerWriterApplication {
 
-    private static final Logger LOGGER =
-        LogManager.getLogger(LedgerWriterApplication.class);
+    private static final Logger LOGGER = LogManager.getLogger(LedgerWriterApplication.class);
 
     private static final String[] EXPECTED_ENV_VARS = {
-        "VERSION",
-        "PORT",
-        "LOCAL_ROUTING_NUM",
-        "BALANCES_API_ADDR",
-        "PUB_KEY_PATH",
-        "SPRING_DATASOURCE_URL",
-        "SPRING_DATASOURCE_USERNAME",
-        "SPRING_DATASOURCE_PASSWORD"
+            "VERSION",
+            "PORT",
+            "LOCAL_ROUTING_NUM",
+            "BALANCES_API_ADDR",
+            "PUB_KEY_PATH",
+            "SPRING_DATASOURCE_URL",
+            "SPRING_DATASOURCE_USERNAME",
+            "SPRING_DATASOURCE_PASSWORD"
     };
 
     public static void main(String[] args) {
@@ -59,14 +58,14 @@ public class LedgerWriterApplication {
             String value = System.getenv(v);
             if (value == null) {
                 LOGGER.fatal(String.format(
-                    "%s environment variable not set", v));
+                        "%s environment variable not set", v));
                 System.exit(1);
             }
         }
         SpringApplication.run(LedgerWriterApplication.class, args);
         LOGGER.log(Level.forName("STARTUP", Level.FATAL.intLevel()),
-            String.format("Started LedgerWriter service. Log level is: %s",
-                LOGGER.getLevel().toString()));
+                String.format("Started LedgerWriter service. Log level is: %s",
+                        LOGGER.getLevel().toString()));
     }
 
     @Bean
@@ -93,28 +92,27 @@ public class LedgerWriterApplication {
                 boolean enableMetricsExport = true;
 
                 if (System.getenv("ENABLE_METRICS") != null
-                    && System.getenv("ENABLE_METRICS").equals("false")) {
+                        && System.getenv("ENABLE_METRICS").equals("false")) {
                     enableMetricsExport = false;
                 }
 
                 LOGGER.info(String.format("Enable metrics export: %b",
-                    enableMetricsExport));
+                        enableMetricsExport));
                 return enableMetricsExport;
             }
 
             @Override
             public String projectId() {
-                String id = MetadataConfig.getProjectId();
-                if (id == null) {
-                    id = "";
-                }
-                return id;
+                return resolveProjectId(
+                        System.getenv("GOOGLE_CLOUD_PROJECT"),
+                        MetadataConfig.getProjectId());
             }
 
             @Override
             public String get(String key) {
                 return null;
             }
+
             @Override
             public String resourceType() {
                 return "k8s_container";
@@ -125,7 +123,7 @@ public class LedgerWriterApplication {
                 Map<String, String> map = new HashMap<>();
                 String podName = System.getenv("HOSTNAME");
                 String containerName = podName.substring(0,
-                    podName.indexOf("-"));
+                        podName.indexOf("-"));
                 map.put("location", MetadataConfig.getZone());
                 map.put("container_name", containerName);
                 map.put("pod_name", podName);
@@ -134,5 +132,25 @@ public class LedgerWriterApplication {
                 return map;
             }
         }).build();
+    }
+
+    /**
+     * Resolves the GCP project ID for metrics export.
+     * Prefers the GOOGLE_CLOUD_PROJECT env var over the GCE metadata server
+     * to support cross-project Workload Identity setups (issue #2309).
+     *
+     * @param envProjectId      value of GOOGLE_CLOUD_PROJECT env var (may be null)
+     * @param metadataProjectId value from GCE metadata server (may be null)
+     * @return resolved project ID, or empty string if both are null
+     */
+    static String resolveProjectId(String envProjectId,
+            String metadataProjectId) {
+        if (envProjectId != null && !envProjectId.isEmpty()) {
+            return envProjectId;
+        }
+        if (metadataProjectId != null) {
+            return metadataProjectId;
+        }
+        return "";
     }
 }

--- a/src/ledger/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
+++ b/src/ledger/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package anthos.samples.bankofanthos.ledgerwriter;
 
 import com.google.cloud.MetadataConfig;

--- a/src/ledger/ledgerwriter/src/main/resources/application.properties
+++ b/src/ledger/ledgerwriter/src/main/resources/application.properties
@@ -18,6 +18,8 @@ spring.main.banner-mode=off
 # tracing on/off toggle
 spring.sleuth.enabled = ${ENABLE_TRACING}
 spring.cloud.gcp.trace.enabled=${ENABLE_TRACING}
+# Override GCP project for metrics/tracing (supports cross-project Workload Identity)
+spring.cloud.gcp.project-id=${GOOGLE_CLOUD_PROJECT:}
 # if tracing enabled, configuration options:
 spring.sleuth.sampler.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)

--- a/src/ledger/ledgerwriter/src/test/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplicationTest.java
+++ b/src/ledger/ledgerwriter/src/test/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplicationTest.java
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package anthos.samples.bankofanthos.ledgerwriter;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/ledger/ledgerwriter/src/test/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplicationTest.java
+++ b/src/ledger/ledgerwriter/src/test/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplicationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020, Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package anthos.samples.bankofanthos.ledgerwriter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for project ID resolution logic in LedgerWriterApplication.
+ * Verifies fix for issue #2309: GOOGLE_CLOUD_PROJECT env var should
+ * take precedence over the GCE metadata server project.
+ */
+class LedgerWriterApplicationTest {
+
+    @Test
+    @DisplayName("When GOOGLE_CLOUD_PROJECT is set, use it over metadata")
+    void resolveProjectIdPrefersEnvVar() {
+        String result = LedgerWriterApplication.resolveProjectId(
+                "project-b", "project-a");
+        assertEquals("project-b", result);
+    }
+
+    @Test
+    @DisplayName("When GOOGLE_CLOUD_PROJECT is null, fall back to metadata")
+    void resolveProjectIdFallsBackToMetadata() {
+        String result = LedgerWriterApplication.resolveProjectId(
+                null, "project-a");
+        assertEquals("project-a", result);
+    }
+
+    @Test
+    @DisplayName("When GOOGLE_CLOUD_PROJECT is empty, fall back to metadata")
+    void resolveProjectIdFallsBackToMetadataWhenEmpty() {
+        String result = LedgerWriterApplication.resolveProjectId(
+                "", "project-a");
+        assertEquals("project-a", result);
+    }
+
+    @Test
+    @DisplayName("When both are null, return empty string")
+    void resolveProjectIdReturnsEmptyWhenBothNull() {
+        String result = LedgerWriterApplication.resolveProjectId(
+                null, null);
+        assertEquals("", result);
+    }
+
+    @Test
+    @DisplayName("When env var is set and metadata is null, use env var")
+    void resolveProjectIdUsesEnvVarWhenMetadataNull() {
+        String result = LedgerWriterApplication.resolveProjectId(
+                "project-b", null);
+        assertEquals("project-b", result);
+    }
+}

--- a/src/ledger/ledgerwriter/src/test/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplicationTest.java
+++ b/src/ledger/ledgerwriter/src/test/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplicationTest.java
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020, Google LLC.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
@@ -38,17 +38,16 @@ import org.springframework.context.annotation.Bean;
 @SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 public class TransactionHistoryApplication {
 
-    private static final Logger LOGGER =
-        LogManager.getLogger(TransactionHistoryApplication.class);
+    private static final Logger LOGGER = LogManager.getLogger(TransactionHistoryApplication.class);
 
     private static final String[] EXPECTED_ENV_VARS = {
-        "VERSION",
-        "PORT",
-        "LOCAL_ROUTING_NUM",
-        "PUB_KEY_PATH",
-        "SPRING_DATASOURCE_URL",
-        "SPRING_DATASOURCE_USERNAME",
-        "SPRING_DATASOURCE_PASSWORD"
+            "VERSION",
+            "PORT",
+            "LOCAL_ROUTING_NUM",
+            "PUB_KEY_PATH",
+            "SPRING_DATASOURCE_URL",
+            "SPRING_DATASOURCE_USERNAME",
+            "SPRING_DATASOURCE_PASSWORD"
     };
 
     public static void main(String[] args) {
@@ -57,14 +56,14 @@ public class TransactionHistoryApplication {
             String value = System.getenv(v);
             if (value == null) {
                 LOGGER.fatal(String.format(
-                    "%s environment variable not set", v));
+                        "%s environment variable not set", v));
                 System.exit(1);
             }
         }
         SpringApplication.run(TransactionHistoryApplication.class, args);
         LOGGER.log(Level.forName("STARTUP", Level.FATAL.intLevel()),
-            String.format("Started TransactionHistory service. "
-                + "Log level is: %s", LOGGER.getLevel().toString()));
+                String.format("Started TransactionHistory service. "
+                        + "Log level is: %s", LOGGER.getLevel().toString()));
     }
 
     @PreDestroy
@@ -86,29 +85,27 @@ public class TransactionHistoryApplication {
                 boolean enableMetricsExport = true;
 
                 if (System.getenv("ENABLE_METRICS") != null
-                    && System.getenv("ENABLE_METRICS").equals("false")) {
+                        && System.getenv("ENABLE_METRICS").equals("false")) {
                     enableMetricsExport = false;
                 }
 
                 LOGGER.info(String.format("Enable metrics export: %b",
-                    enableMetricsExport));
+                        enableMetricsExport));
                 return enableMetricsExport;
             }
 
-
             @Override
             public String projectId() {
-                String id = MetadataConfig.getProjectId();
-                if (id == null) {
-                    id = "";
-                }
-                return id;
+                return resolveProjectId(
+                        System.getenv("GOOGLE_CLOUD_PROJECT"),
+                        MetadataConfig.getProjectId());
             }
 
             @Override
             public String get(String key) {
                 return null;
             }
+
             @Override
             public String resourceType() {
                 return "k8s_container";
@@ -119,7 +116,7 @@ public class TransactionHistoryApplication {
                 Map<String, String> map = new HashMap<>();
                 String podName = System.getenv("HOSTNAME");
                 String containerName = podName.substring(0,
-                    podName.indexOf("-"));
+                        podName.indexOf("-"));
                 map.put("location", MetadataConfig.getZone());
                 map.put("container_name", containerName);
                 map.put("pod_name", podName);
@@ -128,5 +125,25 @@ public class TransactionHistoryApplication {
                 return map;
             }
         }).build();
+    }
+
+    /**
+     * Resolves the GCP project ID for metrics export.
+     * Prefers the GOOGLE_CLOUD_PROJECT env var over the GCE metadata server
+     * to support cross-project Workload Identity setups (issue #2309).
+     *
+     * @param envProjectId      value of GOOGLE_CLOUD_PROJECT env var (may be null)
+     * @param metadataProjectId value from GCE metadata server (may be null)
+     * @return resolved project ID, or empty string if both are null
+     */
+    static String resolveProjectId(String envProjectId,
+            String metadataProjectId) {
+        if (envProjectId != null && !envProjectId.isEmpty()) {
+            return envProjectId;
+        }
+        if (metadataProjectId != null) {
+            return metadataProjectId;
+        }
+        return "";
     }
 }

--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package anthos.samples.bankofanthos.transactionhistory;
 
 import com.google.cloud.MetadataConfig;

--- a/src/ledger/transactionhistory/src/main/resources/application.properties
+++ b/src/ledger/transactionhistory/src/main/resources/application.properties
@@ -18,6 +18,8 @@ spring.main.banner-mode=off
 # tracing on/off toggle
 spring.sleuth.enabled = ${ENABLE_TRACING}
 spring.cloud.gcp.trace.enabled=${ENABLE_TRACING}
+# Override GCP project for metrics/tracing (supports cross-project Workload Identity)
+spring.cloud.gcp.project-id=${GOOGLE_CLOUD_PROJECT:}
 # if tracing enabled, configuration options:
 spring.sleuth.sampler.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)

--- a/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplicationTest.java
+++ b/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplicationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020, Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package anthos.samples.bankofanthos.transactionhistory;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for project ID resolution logic in TransactionHistoryApplication.
+ * Verifies fix for issue #2309: GOOGLE_CLOUD_PROJECT env var should
+ * take precedence over the GCE metadata server project.
+ */
+class TransactionHistoryApplicationTest {
+
+    @Test
+    @DisplayName("When GOOGLE_CLOUD_PROJECT is set, use it over metadata")
+    void resolveProjectIdPrefersEnvVar() {
+        String result = TransactionHistoryApplication.resolveProjectId(
+                "project-b", "project-a");
+        assertEquals("project-b", result);
+    }
+
+    @Test
+    @DisplayName("When GOOGLE_CLOUD_PROJECT is null, fall back to metadata")
+    void resolveProjectIdFallsBackToMetadata() {
+        String result = TransactionHistoryApplication.resolveProjectId(
+                null, "project-a");
+        assertEquals("project-a", result);
+    }
+
+    @Test
+    @DisplayName("When GOOGLE_CLOUD_PROJECT is empty, fall back to metadata")
+    void resolveProjectIdFallsBackToMetadataWhenEmpty() {
+        String result = TransactionHistoryApplication.resolveProjectId(
+                "", "project-a");
+        assertEquals("project-a", result);
+    }
+
+    @Test
+    @DisplayName("When both are null, return empty string")
+    void resolveProjectIdReturnsEmptyWhenBothNull() {
+        String result = TransactionHistoryApplication.resolveProjectId(
+                null, null);
+        assertEquals("", result);
+    }
+
+    @Test
+    @DisplayName("When env var is set and metadata is null, use env var")
+    void resolveProjectIdUsesEnvVarWhenMetadataNull() {
+        String result = TransactionHistoryApplication.resolveProjectId(
+                "project-b", null);
+        assertEquals("project-b", result);
+    }
+}

--- a/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplicationTest.java
+++ b/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplicationTest.java
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package anthos.samples.bankofanthos.transactionhistory;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplicationTest.java
+++ b/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplicationTest.java
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020, Google LLC.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Fixes #2309

### Background 
The Java ledger services (`balancereader`, `ledgerwriter`, `transactionhistory`) were resolving their GCP Project ID solely via `MetadataConfig.getProjectId()`, which queries the GCE metadata server. This meant they always used the hosting project's ID, ignoring the `GOOGLE_CLOUD_PROJECT` environment variable. This behavior broke cross-project Workload Identity setups (e.g., GKE cluster in Project A, Service Account/Monitoring in Project B).

### Change Summary
- **Java Services:** Updated `projectId()` in `BalanceReaderApplication.java`, `LedgerWriterApplication.java`, and `TransactionHistoryApplication.java` to check `System.getenv("GOOGLE_CLOUD_PROJECT")` first. It falls back to the metadata server only if the env var is missing.
- **Spring Config:** Added `spring.cloud.gcp.project-id=${GOOGLE_CLOUD_PROJECT:}` to `application.properties` for all three services to ensure Spring Cloud GCP tracing also respects the environment variable.
- **Kubernetes Manifests:** Added a commented-out `GOOGLE_CLOUD_PROJECT` field to the `environment-config` ConfigMap in `config.yaml` to document how to configure this.
- **Tests:** Added unit tests for `resolveProjectId` logic in all three services.

### Additional Notes
This change is non-breaking for existing deployments as usage of the `GOOGLE_CLOUD_PROJECT` environment variable is optional. Behavior defaults to the metadata server (existing behavior) if the variable is unset.

### Testing Procedure
**Automated Testing:**
- Ran `mvnw test` for all 3 services.
- **Results:** 53 tests passed, 0 failures.

**Manual Verification (GKE):**
1. Built custom Jib images for the 3 modified services.
2. Deployed to a GKE cluster with `GOOGLE_CLOUD_PROJECT` set in the ConfigMap.
3. **Verification:**
    - Confirmed `config.yaml` applied the environment variable.
    - Verified pods started successfully (`Running` status).
    - Verified metrics and logs were correctly exported to the target GCP project in Cloud Monitoring.

### Related PRs or Issues 
Fixes #2309
<img width="1284" height="727" alt="configmap" src="https://github.com/user-attachments/assets/59b28ac7-1ff7-4905-b5ec-a11737b70d54" />
<img width="1073" height="740" alt="logs" src="https://github.com/user-attachments/assets/5383d144-15f8-42ff-9245-1df496aa7bc3" />
<img width="1835" height="1242" alt="Screenshot_20260218_220920" src="https://github.com/user-attachments/assets/09446f38-6de4-44e8-a1db-e8ce37d18a4f" />
