### PR TITLE
Fix obsolete Docker ENV format

### DIFF
--- a/src/accounts/contacts/Dockerfile
+++ b/src/accounts/contacts/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=0
 
 # explicitly set a fallback log level in case no log level is defined by Kubernetes
-ENV LOG_LEVEL info
+ENV LOG_LEVEL=info
 
 # Add application code.
 COPY . .

--- a/src/accounts/userservice/Dockerfile
+++ b/src/accounts/userservice/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=0
 
 # explicitly set a fallback log level in case no log level is defined by Kubernetes
-ENV LOG_LEVEL info
+ENV LOG_LEVEL=info
 
 # Add application code.
 COPY . .

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=0
 
 # explicitly set a fallback log level in case no log level is defined by Kubernetes
-ENV LOG_LEVEL info
+ENV LOG_LEVEL=info
 
 # Add application code.
 COPY . .

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -43,7 +43,7 @@ ENV PYTHONUNBUFFERED=0
 ENV GEVENT_SUPPORT=True
 
 # explicitly set a fallback log level in case no log level is defined by Kubernetes
-ENV LOG_LEVEL info
+ENV LOG_LEVEL=info
 
 # start loadgenerator
 ENTRYPOINT locust --host="http://${FRONTEND_ADDR}" --loglevel $LOG_LEVEL --headless --users="${USERS:-10}" 2>&1


### PR DESCRIPTION
This PR fixes the obsolete Docker ENV format to use the up-to-date `ENV key=value` format.

https://docs.docker.com/reference/dockerfile/#env