### PR TITLE
chore: update from java 17 to 25

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -50,11 +50,11 @@ jobs:
             exit 1
           fi
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '25'
           cache: 'maven'
 
       - name: Install Skaffold

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,20 +16,20 @@ required tools built-in.
 1. [Docker Engine or Docker Desktop](https://www.docker.com/)
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (can be installed separately or via [gcloud](https://cloud.google.com/sdk/install))
 1. [skaffold **2.9+**](https://skaffold.dev/docs/install/) (latest version recommended)
-1. [OpenJDK **21+**](https://openjdk.java.net/projects/jdk/21/) (newer versions not tested)
+1. [OpenJDK **25+**](https://openjdk.java.net/projects/jdk/25/) (newer versions not tested)
 1. [Maven **3.9+**](https://downloads.apache.org/maven/maven-3/) (newer versions not tested)
 1. [Python **3.14+**](https://www.python.org/downloads/)
 1. [uv](https://docs.astral.sh/uv/)
 
-### Installing JDK 21 and Maven 3.9
+### Installing JDK 25 and Maven 3.9
 
-If your package manager doesn't allow you to install JDK 17 or Maven 3.8 (for example, if you're on an older version of Ubuntu), you can follow the following instructions.
+If your package manager doesn't allow you to install JDK 25 or Maven 3.9 (for example, if you're on an older version of Ubuntu), you can follow the following instructions.
 
-Find the [latest release of JDK 21](https://jdk.java.net/21/) and extract it to the `/opt` directory:
+Find the [latest release of JDK 25](https://jdk.java.net/25/) and extract it to the `/opt` directory:
 ```
-wget https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-x64_bin.tar.gz
-tar xvf openjdk-21.0.1_linux-x64_bin.tar.gz
-sudo mv jdk-21.*/ /opt/jdk21
+wget https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz
+tar xvf openjdk-25_linux-x64_bin.tar.gz
+sudo mv jdk-25*/ /opt/jdk25
 ```
 
 Find the [latest release of Maven 3.9](https://maven.apache.org/download.cgi) and
@@ -42,7 +42,7 @@ sudo tar xf apache-maven-*.tar.gz -C /opt
 Create a profile containing the paths of the newly extracted JDK and Maven directories:
 ```
 sudo tee /etc/profile.d/java.sh <<EOF
-export JAVA_HOME=/opt/jdk21
+export JAVA_HOME=/opt/jdk25
 export M2_HOME=/opt/apache-maven-3.9.5
 export MAVEN_HOME=/opt/apache-maven-3.9.5
 export PATH=\$JAVA_HOME/bin:\$M2_HOME/bin:\$PATH

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,9 @@
         <module>src/ledger/balancereader</module>
         <module>src/ledgermonolith</module>
     </modules>
+    <properties>
+        <maven.compiler.release>25</maven.compiler.release>
+    </properties>
 
     <build>
         <pluginManagement>

--- a/src/ledger/balancereader/pom.xml
+++ b/src/ledger/balancereader/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <bootstrap.version>4.6.2</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
@@ -181,7 +181,7 @@
                 <version>3.5.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
+                        <image>eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledger/ledgerwriter/pom.xml
+++ b/src/ledger/ledgerwriter/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <bootstrap.version>4.6.2</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
@@ -171,7 +171,7 @@
                 <version>3.5.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
+                        <image>eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledger/transactionhistory/pom.xml
+++ b/src/ledger/transactionhistory/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <bootstrap.version>4.6.2</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
@@ -181,7 +181,7 @@
                 <version>3.5.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
+                        <image>eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledgermonolith/init/install-script.sh
+++ b/src/ledgermonolith/init/install-script.sh
@@ -91,8 +91,8 @@ function install_service() {
     return
   fi
 
-  # Install Java 17
-  wget --no-verbose https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-x64_bin.tar.gz
+  # Install Java 25
+  wget --no-verbose https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz
   tar xf openjdk-*.tar.gz -C /opt
 
   # Install gcloud if not already installed
@@ -113,7 +113,7 @@ function install_service() {
   cat <<EOF >${MONOLITH_DIR}/ledgermonolith-service.sh
 #!/bin/bash
 source <(sed -E -n 's/[^#]+/export &/ p' ${MONOLITH_DIR}/${APP_ENV})
-export JAVA_HOME=/opt/jdk-17.0.1
+export JAVA_HOME=/opt/jdk-25
 export PATH=\$JAVA_HOME/bin:\$PATH
 java -jar ${MONOLITH_DIR}/${APP_JAR} > ${MONOLITH_LOG}
 EOF

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <bootstrap.version>4.2.1</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
         <spring-cloud.version>2022.0.5</spring-cloud.version>
@@ -155,7 +155,7 @@
                 <version>3.5.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
+                        <image>eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0</image>
                     </from>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary
Upgrades the backend Java microservices and monolith from Java 17 to Java 25 (LTS), 
as tracked in #2494.

## Changes
- **`pom.xml` (root)**: added `maven.compiler.release=25` to enforce the target 
  bytecode version at the parent level
- **Service `pom.xml` files** — updated `<java.version>` from `17` to `25` and 
  updated the Jib base image from `eclipse-temurin:17.0.4.1_1-jre-alpine` to a 
  pinned `eclipse-temurin:25-jre-alpine` digest, in:
  - `src/ledger/balancereader/pom.xml`
  - `src/ledger/ledgerwriter/pom.xml`
  - `src/ledger/transactionhistory/pom.xml`
  - `src/ledgermonolith/pom.xml`
- **`.github/workflows/make-release.yaml`**: updated the `actions/setup-java` step 
  to install JDK 25 instead of JDK 17
- **`docs/development.md`**: updated prerequisites and manual install instructions 
  to reference JDK 25 instead of JDK 21, including the download URL and `JAVA_HOME` 
  path
- **`src/ledgermonolith/init/install-script.sh`**: updated the JDK download step 
  and `JAVA_HOME` export to install and reference JDK 25 instead of JDK 17

## Testing
- Ran `./mvnw clean test` — all builds and test suites pass on JDK 25

## Notes for reviewers
- The Jib image digest for `eclipse-temurin:25-jre-alpine` was pinned as of the 
  time of this PR; happy to re-verify/update it if it's since moved.
- Added `maven.compiler.release` at the root `pom.xml` in addition to the 
  per-module `java.version` bumps, since it enforces the release target more 
  strictly during compilation — let me know if you'd prefer to keep it scoped to 
  the per-module properties only.

Fixes #2494