### PR TITLE
chore: upgrade to Java 25 and Spring Boot 4

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -50,11 +50,11 @@ jobs:
             exit 1
           fi
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '25'
           cache: 'maven'
 
       - name: Install Skaffold

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,20 +16,20 @@ required tools built-in.
 1. [Docker Engine or Docker Desktop](https://www.docker.com/)
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (can be installed separately or via [gcloud](https://cloud.google.com/sdk/install))
 1. [skaffold **2.9+**](https://skaffold.dev/docs/install/) (latest version recommended)
-1. [OpenJDK **21+**](https://openjdk.java.net/projects/jdk/21/) (newer versions not tested)
+1. [OpenJDK **25+**](https://openjdk.java.net/projects/jdk/25/) (newer versions not tested)
 1. [Maven **3.9+**](https://downloads.apache.org/maven/maven-3/) (newer versions not tested)
 1. [Python **3.14+**](https://www.python.org/downloads/)
 1. [uv](https://docs.astral.sh/uv/)
 
-### Installing JDK 21 and Maven 3.9
+### Installing JDK 25 and Maven 3.9
 
-If your package manager doesn't allow you to install JDK 17 or Maven 3.8 (for example, if you're on an older version of Ubuntu), you can follow the following instructions.
+If your package manager doesn't allow you to install JDK 25 or Maven 3.9 (for example, if you're on an older version of Ubuntu), you can follow the following instructions.
 
-Find the [latest release of JDK 21](https://jdk.java.net/21/) and extract it to the `/opt` directory:
+Find the [latest release of JDK 25](https://jdk.java.net/25/) and extract it to the `/opt` directory:
 ```
-wget https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-x64_bin.tar.gz
-tar xvf openjdk-21.0.1_linux-x64_bin.tar.gz
-sudo mv jdk-21.*/ /opt/jdk21
+wget https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz
+tar xvf openjdk-25_linux-x64_bin.tar.gz
+sudo mv jdk-25*/ /opt/jdk25
 ```
 
 Find the [latest release of Maven 3.9](https://maven.apache.org/download.cgi) and
@@ -42,7 +42,7 @@ sudo tar xf apache-maven-*.tar.gz -C /opt
 Create a profile containing the paths of the newly extracted JDK and Maven directories:
 ```
 sudo tee /etc/profile.d/java.sh <<EOF
-export JAVA_HOME=/opt/jdk21
+export JAVA_HOME=/opt/jdk25
 export M2_HOME=/opt/apache-maven-3.9.5
 export MAVEN_HOME=/opt/apache-maven-3.9.5
 export PATH=\$JAVA_HOME/bin:\$M2_HOME/bin:\$PATH

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,9 @@
         <module>src/ledger/balancereader</module>
         <module>src/ledgermonolith</module>
     </modules>
+    <properties>
+        <maven.compiler.release>25</maven.compiler.release>
+    </properties>
 
     <build>
         <pluginManagement>

--- a/src/ledger/balancereader/pom.xml
+++ b/src/ledger/balancereader/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <bootstrap.version>4.6.2</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
@@ -181,7 +181,7 @@
                 <version>3.5.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
+                        <image>eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledger/balancereader/pom.xml
+++ b/src/ledger/balancereader/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.15</version>
+        <version>4.0.7</version>
     </parent>
 
     <properties>
@@ -78,7 +78,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -137,17 +137,14 @@
         <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-          <version>32.1.3-jre</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>6.8.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>
@@ -157,7 +154,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -195,7 +191,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/ledger/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
+++ b/src/ledger/balancereader/src/main/java/anthos/samples/bankofanthos/balancereader/BalanceReaderApplication.java
@@ -21,12 +21,11 @@ import io.micrometer.stackdriver.StackdriverConfig;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
@@ -35,7 +34,7 @@ import org.springframework.context.annotation.Bean;
  *
  * Microservice to track the bank balance for each user account.
  */
-@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
+@SpringBootApplication
 public class BalanceReaderApplication {
 
     private static final Logger LOGGER =

--- a/src/ledger/balancereader/src/main/resources/application.properties
+++ b/src/ledger/balancereader/src/main/resources/application.properties
@@ -16,10 +16,10 @@ server.port = ${PORT}
 handlers = java.util.logging.ConsoleHandler
 spring.main.banner-mode=off
 # tracing on/off toggle
-spring.sleuth.enabled = ${ENABLE_TRACING}
+management.tracing.export.enabled = ${ENABLE_TRACING}
 spring.cloud.gcp.trace.enabled=${ENABLE_TRACING}
 # if tracing enabled, configuration options:
-spring.sleuth.sampler.probability=1.0
+management.tracing.sampling.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)
 spring.sleuth.log.slf4j.enabled=false
 #enables all tomcat metrics to be recorded

--- a/src/ledger/balancereader/src/test/java/anthos/samples/bankofanthos/balancereader/BalanceReaderControllerTest.java
+++ b/src/ledger/balancereader/src/test/java/anthos/samples/bankofanthos/balancereader/BalanceReaderControllerTest.java
@@ -16,11 +16,9 @@
 
 package anthos.samples.bankofanthos.balancereader;
 
-import com.google.common.cache.CacheLoader;
 import com.google.common.cache.CacheStats;
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
-import io.micrometer.core.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micrometer.stackdriver.StackdriverConfig;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
 import java.util.concurrent.ExecutionException;
@@ -29,16 +27,13 @@ import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.LoadingCache;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.ResourceAccessException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/src/ledger/ledgerwriter/pom.xml
+++ b/src/ledger/ledgerwriter/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.15</version>
+        <version>4.0.7</version>
     </parent>
 
     <properties>
@@ -78,7 +78,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -111,6 +111,10 @@
             <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-restclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.26.0</version>
@@ -127,17 +131,14 @@
         <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-          <version>32.1.3-jre</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>6.8.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>
@@ -147,7 +148,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -185,7 +185,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/ledger/ledgerwriter/pom.xml
+++ b/src/ledger/ledgerwriter/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <bootstrap.version>4.6.2</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
@@ -171,7 +171,7 @@
                 <version>3.5.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
+                        <image>eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledger/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
+++ b/src/ledger/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterApplication.java
@@ -21,12 +21,11 @@ import io.micrometer.stackdriver.StackdriverConfig;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
@@ -36,7 +35,7 @@ import org.springframework.web.client.RestTemplate;
  *
  * Microservice to accept new transactions for the bank ledger.
  */
-@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
+@SpringBootApplication
 public class LedgerWriterApplication {
 
     private static final Logger LOGGER =

--- a/src/ledger/ledgerwriter/src/main/resources/application.properties
+++ b/src/ledger/ledgerwriter/src/main/resources/application.properties
@@ -16,10 +16,10 @@ server.port = ${PORT}
 handlers = java.util.logging.ConsoleHandler
 spring.main.banner-mode=off
 # tracing on/off toggle
-spring.sleuth.enabled = ${ENABLE_TRACING}
+management.tracing.export.enabled = ${ENABLE_TRACING}
 spring.cloud.gcp.trace.enabled=${ENABLE_TRACING}
 # if tracing enabled, configuration options:
-spring.sleuth.sampler.probability=1.0
+management.tracing.sampling.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)
 spring.sleuth.log.slf4j.enabled=false
 #enables all tomcat metrics to be recorded

--- a/src/ledger/ledgerwriter/src/test/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterControllerTest.java
+++ b/src/ledger/ledgerwriter/src/test/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterControllerTest.java
@@ -32,7 +32,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micrometer.stackdriver.StackdriverConfig;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/ledger/transactionhistory/pom.xml
+++ b/src/ledger/transactionhistory/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <bootstrap.version>4.6.2</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
@@ -181,7 +181,7 @@
                 <version>3.5.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
+                        <image>eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledger/transactionhistory/pom.xml
+++ b/src/ledger/transactionhistory/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.15</version>
+        <version>4.0.7</version>
     </parent>
 
     <properties>
@@ -78,7 +78,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -137,17 +137,14 @@
         <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-          <version>32.1.3-jre</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>6.8.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>
@@ -157,7 +154,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -196,7 +192,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryApplication.java
@@ -21,12 +21,11 @@ import io.micrometer.stackdriver.StackdriverConfig;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
@@ -35,7 +34,7 @@ import org.springframework.context.annotation.Bean;
  *
  * Microservice to track the transaction history for each bank account.
  */
-@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
+@SpringBootApplication
 public class TransactionHistoryApplication {
 
     private static final Logger LOGGER =

--- a/src/ledger/transactionhistory/src/main/resources/application.properties
+++ b/src/ledger/transactionhistory/src/main/resources/application.properties
@@ -16,10 +16,10 @@ server.port = ${PORT}
 handlers = java.util.logging.ConsoleHandler
 spring.main.banner-mode=off
 # tracing on/off toggle
-spring.sleuth.enabled = ${ENABLE_TRACING}
+management.tracing.export.enabled = ${ENABLE_TRACING}
 spring.cloud.gcp.trace.enabled=${ENABLE_TRACING}
 # if tracing enabled, configuration options:
-spring.sleuth.sampler.probability=1.0
+management.tracing.sampling.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)
 spring.sleuth.log.slf4j.enabled=false
 #enables all tomcat metrics to be recorded

--- a/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryControllerTest.java
+++ b/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryControllerTest.java
@@ -28,7 +28,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.common.cache.CacheStats;
 import com.google.common.cache.LoadingCache;
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micrometer.stackdriver.StackdriverConfig;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
 import java.util.Deque;

--- a/src/ledgermonolith/init/install-script.sh
+++ b/src/ledgermonolith/init/install-script.sh
@@ -91,8 +91,8 @@ function install_service() {
     return
   fi
 
-  # Install Java 17
-  wget --no-verbose https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-x64_bin.tar.gz
+  # Install Java 25
+  wget --no-verbose https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz
   tar xf openjdk-*.tar.gz -C /opt
 
   # Install gcloud if not already installed
@@ -113,7 +113,7 @@ function install_service() {
   cat <<EOF >${MONOLITH_DIR}/ledgermonolith-service.sh
 #!/bin/bash
 source <(sed -E -n 's/[^#]+/export &/ p' ${MONOLITH_DIR}/${APP_ENV})
-export JAVA_HOME=/opt/jdk-17.0.1
+export JAVA_HOME=/opt/jdk-25
 export PATH=\$JAVA_HOME/bin:\$PATH
 java -jar ${MONOLITH_DIR}/${APP_JAR} > ${MONOLITH_LOG}
 EOF

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <bootstrap.version>4.2.1</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
         <spring-cloud.version>2022.0.5</spring-cloud.version>
@@ -155,7 +155,7 @@
                 <version>3.5.1</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:17.0.4.1_1-jre-alpine@sha256:e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767</image>
+                        <image>eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0</image>
                     </from>
                 </configuration>
             </plugin>

--- a/src/ledgermonolith/pom.xml
+++ b/src/ledgermonolith/pom.xml
@@ -28,14 +28,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.15</version>
+        <version>4.0.7</version>
     </parent>
 
     <properties>
         <java.version>25</java.version>
         <bootstrap.version>4.2.1</bootstrap.version>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
-        <spring-cloud.version>2022.0.5</spring-cloud.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
@@ -67,7 +67,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -100,6 +100,10 @@
             <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-restclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.26.0</version>
@@ -116,17 +120,14 @@
         <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-          <version>32.1.3-jre</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>6.8.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>
@@ -136,7 +137,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -169,7 +169,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/LedgerMonolithApplication.java
+++ b/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/LedgerMonolithApplication.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
@@ -29,7 +28,7 @@ import org.springframework.web.client.RestTemplate;
  * Entry point for the LedgerMonolith Spring Boot application.
  *
  */
-@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
+@SpringBootApplication
 public class LedgerMonolithApplication {
 
     private static final Logger LOGGER =

--- a/src/ledgermonolith/src/main/resources/application.properties
+++ b/src/ledgermonolith/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port = ${PORT}
-logging.file = /var/log/ledgermonolith.log
+logging.file.name = /var/log/ledgermonolith.log
 logging.level.root = INFO
 handlers = java.util.logging.ConsoleHandler
 logging.level.org.springframework.jdbc.datasource.init.ScriptUtils=debug
@@ -13,12 +13,12 @@ spring.main.allow-bean-definition-overriding=true
 
 
 spring.jpa.database=postgresql
-spring.datasource.platform=postgres
+spring.sql.init.platform=postgres
 
 # tracing on/off toggle
-spring.sleuth.enabled = ${ENABLE_TRACING}
+management.tracing.export.enabled = ${ENABLE_TRACING}
 # if tracing enabled, configuration options:
-spring.sleuth.sampler.probability=1.0
+management.tracing.sampling.probability=1.0
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)
 spring.sleuth.log.slf4j.enabled=false
 # enables all tomcat metrics to be recorded


### PR DESCRIPTION
## What this does

Upgrades the ledger services (balancereader, ledgerwriter, transactionhistory) and the
ledgermonolith from Java 17 / Spring Boot 3.5 to **Java 25** and **Spring Boot 4.0.7**.

## Java 25

- Bumped JDK from 17 to 25 across all Maven modules (`java.version`, root `pom.xml`
  `maven.compiler.release`), the release workflow (`make-release.yaml`), the Jib base image
  (`eclipse-temurin:25-jre-alpine`), and the ledgermonolith install script.
- Updated `docs/development.md` to reflect the new JDK 25 / Maven 3.9 prerequisites.

## Spring Boot 4

- Bumped `spring-boot-starter-parent` from `3.5.15` to `4.0.7` in all four service poms.
- `spring-boot-starter-web` → `spring-boot-starter-webmvc` (renamed starter in Boot 4).
- Added `spring-boot-starter-restclient` where `RestTemplate`/`RestClient` beans are used
  (ledgerwriter, ledgermonolith).
- `com.fasterxml.jackson.core:jackson-databind` → `tools.jackson.core:jackson-databind`
  (Jackson 3, now Spring Boot's default databind implementation).
- Dropped explicit version pins on `guava`, `jackson-databind`, `lettuce-core`, and
  `junit-jupiter-engine` — these are now managed by the Spring Boot 4 BOM.
- Removed the `ZipkinAutoConfiguration` import/exclude from each `@SpringBootApplication`
  class — the class moved packages in Boot 4 and isn't needed here since these services use
  GCP Cloud Trace, not Zipkin.
- `javax.annotation.PreDestroy` → `jakarta.annotation.PreDestroy`.
- Replaced deprecated Spring Cloud Sleuth properties with their Micrometer Tracing
  equivalents in `application.properties`:
  - `spring.sleuth.enabled` → `management.tracing.export.enabled`
  - `spring.sleuth.sampler.probability` → `management.tracing.sampling.probability`
- ledgermonolith only: `logging.file` → `logging.file.name`,
  `spring.datasource.platform` → `spring.sql.init.platform` (both renamed in Boot 4),
  and `spring-cloud.version` bumped to `2025.1.2` to stay aligned with the ledger services.
- Test files: `io.micrometer.core.lang.Nullable` → `org.jspecify.annotations.Nullable`
  (Micrometer 1.17 moved to JSpecify for nullability annotations), plus some unused-import
  cleanup in `BalanceReaderControllerTest`.

## Testing

- `mvn clean verify` passes locally for all four modules.

## Notes for reviewers

This branch was built on top of #2503 (Java 17 → 25). If that PR merges first, I'll rebase
this one onto `main` before it's reviewed further.